### PR TITLE
Add github-pages template

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,31 @@
+remote_theme: vaibhavvikas/jekyll-theme-minimalistic
+
+plugins:
+  - jekyll-sitemap
+  - jekyll-seo-tag
+  - jemoji
+  - jekyll-remote-theme
+
+title:  LangChain - ChatGLM
+description:  A local knowledge based LLM Application with ChatGLM-6B and langchain
+favicon: true
+color-scheme: auto
+
+
+# You can find fonts from https://iconify.design or https://fontawesome.com. Below is just an example illustrating how to use custom icons
+platforms:
+  - name: GitHub
+    icon: <i class="fa-brands fa-github"></i>
+    link: https://github.com/imClumsyPanda/langchain-ChatGLM
+
+navigation:
+  - name: Intro
+    link: ./index.html
+  - name: Example
+    link: ./example.html
+    sublist:
+      - name: Installation
+        link: ./example.html#installation
+      - name: Reference
+        link: ./example.html#reference
+

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,0 +1,1 @@
+<p><small>Powered by <a href="https://jekyllrb.com/">Jekyll</a></small></p>

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,0 +1,8 @@
+# Title
+
+## Installation
+Todo 
+
+## Reference
+ - [lang-chain](https://github.com/hwchase17/langchain)
+ - [ChatGLM-6B](https://github.com/THUDM/ChatGLM-6B)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+# Intro
+
+TODO


### PR DESCRIPTION
This is a PR for github-pages

After the repo merged, please enable github-pages by:
1. Goto Repo
2. Setting -> Pages -> Branch
3. Select 'master' branch and '/docs' directory
4. Press 'Save'

Here is an example link on my fork: https://shawnvim.github.io/langchain-ChatGLM/

You can get your own URL by replace the user name from 'shawnvim' to “ imClumsyPanda' when Environment build is finished.