### PR TITLE
使用多进程并行导入多个PDF文件，并提升paddleorc识别效果

### DIFF
--- a/load.py
+++ b/load.py
@@ -1,0 +1,57 @@
+import argparse
+import sys
+import os
+import shutil
+from chains.local_doc_qa import LocalDocQA
+import models.shared as shared
+from models.loader.args import parser
+from models.loader import LoaderCheckPoint
+from chains.local_doc_qa import tree
+
+VS_ROOT_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "vector_store")
+
+UPLOAD_ROOT_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "content")
+
+local_doc_qa = LocalDocQA()
+
+
+def get_vs_path(local_doc_id: str):
+    return os.path.join(VS_ROOT_PATH, local_doc_id)
+
+def get_file_path(local_doc_id: str, doc_name: str):
+    return os.path.join(UPLOAD_ROOT_PATH, local_doc_id, doc_name)
+
+def load_file(path, knowledge_base_id):
+    vs_path = get_vs_path(knowledge_base_id)
+    vs_path, loaded_files, failed_files = local_doc_qa.init_knowledge_vector_store(path, vs_path)
+    if len(loaded_files) > 0:
+        file_status = f"{path} 已上传至知识库 {knowledge_base_id}"
+        print(file_status)
+        if len(failed_files) > 0:
+            print( f"{len(failed_files)}个文件上传失败：{failed_files}")
+        return file_status
+    else:
+        file_status = "文件上传失败，请重新上传"
+        print(file_status)
+        return file_status
+
+if __name__ == "__main__":
+    parser.add_argument("--base", type=str, help='Knowlege Base name, alpha beta charactor only')
+    parser.add_argument("--path", type=str, help='File or Directory to import')
+    args = None
+    args = parser.parse_args()
+    args_dict = vars(args)
+    shared.loaderCheckPoint = LoaderCheckPoint(args_dict)
+    llm_model_ins = shared.loaderLLM()
+    llm_model_ins.set_history_len(10)
+    local_doc_qa.init_cfg(llm_model=llm_model_ins)
+
+    if(os.path.exists(args.path)):
+        # create knowledge path and source content path
+        if not os.path.exists(os.path.join(UPLOAD_ROOT_PATH, args.base)):
+            os.makedirs(os.path.join(UPLOAD_ROOT_PATH, args.base))
+        if not os.path.exists(os.path.join(VS_ROOT_PATH, args.base)):
+            os.makedirs(os.path.join(VS_ROOT_PATH, args.base))
+        load_file(os.path.realpath(args.path), args.base)
+    else:
+        print("path not exist")

--- a/loader/pdf_loader.py
+++ b/loader/pdf_loader.py
@@ -7,6 +7,7 @@ import os
 import fitz
 import nltk
 from configs.model_config import NLTK_DATA_PATH
+import tempfile
 
 nltk.data.path = [NLTK_DATA_PATH] + nltk.data.path
 
@@ -18,10 +19,13 @@ class UnstructuredPaddlePDFLoader(UnstructuredFileLoader):
             full_dir_path = os.path.join(os.path.dirname(filepath), dir_path)
             if not os.path.exists(full_dir_path):
                 os.makedirs(full_dir_path)
-            ocr = PaddleOCR(use_angle_cls=True, lang="ch", use_gpu=False, show_log=False)
+            ocr = PaddleOCR(use_angle_cls=True, lang="ch", use_gpu=False, show_log=False,
+                            det_model_dir="/modules/PaddleOCRModels/ch_PP-OCRv3_det_infer",
+                            cls_model_dir="/modules/PaddleOCRModels/ch_ppocr_mobile_v2.0_cls_infer",
+                            rec_model_dir="/modules/PaddleOCRModels/ch_PP-OCRv3_rec_infer")
             doc = fitz.open(filepath)
             txt_file_path = os.path.join(full_dir_path, f"{os.path.split(filepath)[-1]}.txt")
-            img_name = os.path.join(full_dir_path, 'tmp.png')
+            # img_name = os.path.join(full_dir_path, 'tmp.png')
             with open(txt_file_path, 'w', encoding='utf-8') as fout:
                 for i in range(doc.page_count):
                     page = doc[i]
@@ -34,6 +38,7 @@ class UnstructuredPaddlePDFLoader(UnstructuredFileLoader):
                         pix = fitz.Pixmap(doc, img[0])
                         if pix.n - pix.alpha >= 4:
                             pix = fitz.Pixmap(fitz.csRGB, pix)
+                        fd, img_name = tempfile.mkstemp()
                         pix.save(img_name)
 
                         result = ocr.ocr(img_name)


### PR DESCRIPTION
原项目导入文件时是单进程，在导入多个文件时顺序执行，排队时间较长。使用多进程并行处理，能有效提升导入效率。
增加了 load.py 文件，可在后台导入，不使用web界面，方便大量文件操作。唯一的问题是在已运行的web环境中，使用load.py导入时，会重复引用chatglm模型，导致显存不足。我个人的方案是单独运行一个不执行web环境的容器，用来做数据导入。

使用方法：
python3 load.py --path 文件目录（也可是单个文件） --base 知识库名称（不支持中文）

注意：
paddleocr的模型需要提前下载并放到 loader/pdf_loader.py 中指定的目录
```
ocr = PaddleOCR(use_angle_cls=True, lang="ch", use_gpu=False, show_log=False,
                            det_model_dir="/modules/PaddleOCRModels/ch_PP-OCRv3_det_infer",
                            cls_model_dir="/modules/PaddleOCRModels/ch_ppocr_mobile_v2.0_cls_infer",
                            rec_model_dir="/modules/PaddleOCRModels/ch_PP-OCRv3_rec_infer")
```