### PR TITLE
Update utils.py: correct recreate_vector_store's timeout

### DIFF
--- a/webui_pages/utils.py
+++ b/webui_pages/utils.py
@@ -617,7 +617,7 @@ class ApiRequest:
                 "/knowledge_base/recreate_vector_store",
                 json=data,
                 stream=True,
-                timeout=False,
+                timeout=None,
             )
             return self._httpx_stream2generator(response, as_json=True)
 


### PR DESCRIPTION
use `timeout=None` instead of `timeout=False` to disable httpx's timeout.