### PR TITLE
修复 milvus 作为默认数据库初始化异常和调用search方法异常

### DIFF
--- a/server/knowledge_base/kb_service/milvus_kb_service.py
+++ b/server/knowledge_base/kb_service/milvus_kb_service.py
@@ -45,7 +45,7 @@ class MilvusKBService(KBService):
     def do_drop_kb(self):
         self.milvus.col.drop()
 
-    def do_search(self, query: str, top_k: int, embeddings: Embeddings):
+    def do_search(self, query: str, top_k: int,score_threshold: float, embeddings: Embeddings):
         # todo: support score threshold
         self._load_milvus(embeddings=embeddings)
         return self.milvus.similarity_search_with_score(query, top_k)
@@ -70,7 +70,8 @@ class MilvusKBService(KBService):
         self.milvus.col.delete(expr=f'pk in {delete_list}')
 
     def do_clear_vs(self):
-        self.milvus.col.drop()
+        if not self.milvus.col:
+            self.milvus.col.drop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
修复milvus作为默认数据库初始化异常 #1206  和调用search方法异常 #1229