### PR TITLE
修复 KeyError: 'answer' 错误

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -116,7 +116,7 @@ class KBService(ABC):
                     score_threshold: float = SCORE_THRESHOLD,
                     ):
         embeddings = self._load_embeddings()
-        docs = self.do_search(query, top_k, score_threshold, embeddings)
+        docs = self.do_search(query, top_k, embeddings)
         return docs
 
     @abstractmethod


### PR DESCRIPTION
修复知识库问答时出现的 KeyError: 'answer' 错误