### PR TITLE
fix #1224: json 和 pdf 文档向量化失败

### DIFF
--- a/webui_pages/knowledge_base/knowledge_base.py
+++ b/webui_pages/knowledge_base/knowledge_base.py
@@ -127,7 +127,7 @@ def knowledge_base_page(api: ApiRequest):
 
         # 上传文件
         # sentence_size = st.slider("文本入库分句长度限制", 1, 1000, SENTENCE_SIZE, disabled=True)
-        files = st.file_uploader("上传知识文件",
+        files = st.file_uploader("上传知识文件(暂不支持扫描PDF)",
                                  [i for ls in LOADER_DICT.values() for i in ls],
                                  accept_multiple_files=True,
                                  )


### PR DESCRIPTION
在原先的代码中，json和pdf文档都是通过`UnstructuredFileLoader`进行处理。
`langchain==0.0.266`中对json和pdf文件提供了专门的加载器，再使用`UnstructuredFileLoader`的话，json文件会报错：`Detected a JSON file that does not conform to the Unstructured schema. partition_json currently only processes serialized Unstructured output.`；pdf文件不支持中文。

对文档加载器进行了修改：
1. HTML、Markdown、PDF、JSON改用专门的加载器。
2. 自定义JSON加载器，无需安装`jq`。官方JSON加载器依赖`jq`，在windows下安装不便。
3. HTML和JSON文件启用`mode="elements"`，获得更好的分段效果。但对QA形式的文档需要进一步做适配。

修改后项目依赖无变化，不支持扫描版PDF（原先虽然支持扫描，但不支持中文）。
