### PR TITLE
修复重建知识库界面无反应的问题，添加一些log信息

### DIFF
--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -183,7 +183,7 @@ async def recreate_vector_store(
     set allow_empty_kb to True make it applied on empty knowledge base which it not in the info.db or having no documents.
     '''
 
-    async def output():
+    def output():
         kb = KBServiceFactory.get_service(knowledge_base_name, vs_type, embed_model)
         if not kb.exists() and not allow_empty_kb:
             yield {"code": 404, "msg": f"未找到知识库 ‘{knowledge_base_name}’"}

--- a/webui_pages/knowledge_base/knowledge_base.py
+++ b/webui_pages/knowledge_base/knowledge_base.py
@@ -244,7 +244,6 @@ def knowledge_base_page(api: ApiRequest):
 
         cols = st.columns(3)
 
-        # todo: freezed
         if cols[0].button(
                 "依据源文件重建向量库",
                 # help="无需上传文件，通过其它方式将文档拷贝到对应知识库content目录下，点击本按钮即可重建知识库。",
@@ -258,7 +257,7 @@ def knowledge_base_page(api: ApiRequest):
                     if msg := check_error_msg(d):
                         st.toast(msg)
                     else:
-                        empty.progress(d["finished"] / d["total"], f"正在处理： {d['doc']}")
+                        empty.progress(d["finished"] / d["total"], d["msg"])
                 st.experimental_rerun()
 
         if cols[2].button(


### PR DESCRIPTION
## bug fix:
- 知识库管理页面中，点击重建知识库时，界面不能实时显示进度，看起来像卡死了。


## 其他
- 在ApiRequest中添加一些log信息，方便调试定位chat遇到的问题。(close #1172 )