### PR TITLE
Fix blocking api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs
 __pycache__/
 knowledge_base/
 configs/*.py
+.venv/

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,10 +31,10 @@ $ conda env remove -p  /your_path/env_name
 
 ```shell
 # 拉取仓库
-$ git clone https://github.com/imClumsyPanda/langchain-ChatGLM.git
+$ git clone https://github.com/chatchat-space/Langchain-Chatchat.git
 
 # 进入目录
-$ cd langchain-ChatGLM
+$ cd Langchain-Chatchat
 
 # 安装全部依赖
 $ pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ unstructured[all-docs]
 python-magic-bin; sys_platform == 'win32'
 SQLAlchemy==2.0.19
 faiss-cpu
-nltk
 accelerate
 spacy
 

--- a/server/chat/openai_chat.py
+++ b/server/chat/openai_chat.py
@@ -35,7 +35,7 @@ async def openai_chat(msg: OpenAiChatMsgIn):
         data.pop("stream")
 
         try:
-            response = openai.ChatCompletion.create(**data)
+            response = await openai.ChatCompletion.acreate(**data)
             if msg.stream:
                 for chunk in response.choices[0].message.content:
                     print(chunk)

--- a/server/knowledge_base/kb_api.py
+++ b/server/knowledge_base/kb_api.py
@@ -7,12 +7,12 @@ from configs.model_config import EMBEDDING_MODEL
 from fastapi import Body
 
 
-async def list_kbs():
+def list_kbs():
     # Get List of Knowledge Base
     return ListResponse(data=list_kbs_from_db())
 
 
-async def create_kb(knowledge_base_name: str = Body(..., examples=["samples"]),
+def create_kb(knowledge_base_name: str = Body(..., examples=["samples"]),
                     vector_store_type: str = Body("faiss"),
                     embed_model: str = Body(EMBEDDING_MODEL),
                     ) -> BaseResponse:
@@ -36,7 +36,7 @@ async def create_kb(knowledge_base_name: str = Body(..., examples=["samples"]),
     return BaseResponse(code=200, msg=f"已新增知识库 {knowledge_base_name}")
 
 
-async def delete_kb(
+def delete_kb(
         knowledge_base_name: str = Body(..., examples=["samples"])
     ) -> BaseResponse:
     # Delete selected knowledge base

--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -29,7 +29,7 @@ def search_docs(query: str = Body(..., description="用户输入", examples=["�
     return data
 
 
-async def list_docs(
+def list_docs(
     knowledge_base_name: str
 ) -> ListResponse:
     if not validate_kb_name(knowledge_base_name):
@@ -44,7 +44,7 @@ async def list_docs(
         return ListResponse(data=all_doc_names)
 
 
-async def upload_doc(file: UploadFile = File(..., description="上传文件"),
+def upload_doc(file: UploadFile = File(..., description="上传文件"),
                      knowledge_base_name: str = Form(..., description="知识库名称", examples=["kb1"]),
                      override: bool = Form(False, description="覆盖已有文件"),
                      not_refresh_vs_cache: bool = Form(False, description="暂不保存向量库（用于FAISS）"),
@@ -56,7 +56,7 @@ async def upload_doc(file: UploadFile = File(..., description="上传文件"),
     if kb is None:
         return BaseResponse(code=404, msg=f"未找到知识库 {knowledge_base_name}")
 
-    file_content = await file.read()  # 读取上传文件的内容
+    file_content = file.file.read()  # 读取上传文件的内容
 
     try:
         kb_file = KnowledgeFile(filename=file.filename,
@@ -85,7 +85,7 @@ async def upload_doc(file: UploadFile = File(..., description="上传文件"),
     return BaseResponse(code=200, msg=f"成功上传文件 {kb_file.filename}")
 
 
-async def delete_doc(knowledge_base_name: str = Body(..., examples=["samples"]),
+def delete_doc(knowledge_base_name: str = Body(..., examples=["samples"]),
                      doc_name: str = Body(..., examples=["file_name.md"]),
                      delete_content: bool = Body(False),
                      not_refresh_vs_cache: bool = Body(False, description="暂不保存向量库（用于FAISS）"),
@@ -112,7 +112,7 @@ async def delete_doc(knowledge_base_name: str = Body(..., examples=["samples"]),
     return BaseResponse(code=200, msg=f"{kb_file.filename} 文件删除成功")
 
 
-async def update_doc(
+def update_doc(
         knowledge_base_name: str = Body(..., examples=["samples"]),
         file_name: str = Body(..., examples=["file_name"]),
         not_refresh_vs_cache: bool = Body(False, description="暂不保存向量库（用于FAISS）"),
@@ -140,7 +140,7 @@ async def update_doc(
     return BaseResponse(code=500, msg=f"{kb_file.filename} 文件更新失败")
 
 
-async def download_doc(
+def download_doc(
         knowledge_base_name: str = Query(..., examples=["samples"]),
         file_name: str = Query(..., examples=["test.txt"]),
     ):
@@ -170,7 +170,7 @@ async def download_doc(
     return BaseResponse(code=500, msg=f"{kb_file.filename} 读取文件失败")
 
 
-async def recreate_vector_store(
+def recreate_vector_store(
         knowledge_base_name: str = Body(..., examples=["samples"]),
         allow_empty_kb: bool = Body(True),
         vs_type: str = Body(DEFAULT_VS_TYPE),

--- a/webui_pages/utils.py
+++ b/webui_pages/utils.py
@@ -408,7 +408,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_api import list_kbs
-            response = run_async(list_kbs())
+            response = list_kbs()
             return response.data
         else:
             response = self.get("/knowledge_base/list_knowledge_bases")
@@ -436,7 +436,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_api import create_kb
-            response = run_async(create_kb(**data))
+            response = create_kb(**data)
             return response.dict()
         else:
             response = self.post(
@@ -458,7 +458,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_api import delete_kb
-            response = run_async(delete_kb(knowledge_base_name))
+            response = delete_kb(knowledge_base_name)
             return response.dict()
         else:
             response = self.post(
@@ -480,7 +480,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_doc_api import list_docs
-            response = run_async(list_docs(knowledge_base_name))
+            response = list_docs(knowledge_base_name)
             return response.data
         else:
             response = self.get(
@@ -521,11 +521,11 @@ class ApiRequest:
             temp_file = SpooledTemporaryFile(max_size=10 * 1024 * 1024)
             temp_file.write(file.read())
             temp_file.seek(0)
-            response = run_async(upload_doc(
+            response = upload_doc(
                 UploadFile(file=temp_file, filename=filename),
                 knowledge_base_name,
                 override,
-            ))
+            )
             return response.dict()
         else:
             response = self.post(
@@ -562,7 +562,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_doc_api import delete_doc
-            response = run_async(delete_doc(**data))
+            response = delete_doc(**data)
             return response.dict()
         else:
             response = self.post(
@@ -586,7 +586,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_doc_api import update_doc
-            response = run_async(update_doc(knowledge_base_name, file_name))
+            response = update_doc(knowledge_base_name, file_name)
             return response.dict()
         else:
             response = self.post(
@@ -622,7 +622,7 @@ class ApiRequest:
 
         if no_remote_api:
             from server.knowledge_base.kb_doc_api import recreate_vector_store
-            response = run_async(recreate_vector_store(**data))
+            response = recreate_vector_store(**data)
             return self._fastapi_stream2generator(response, as_json=True)
         else:
             response = self.post(


### PR DESCRIPTION
## 问题
api 中的路由函数均是通过 async 定义的异步路由，但对于向量库以及数据的操作没有都做到完全异步，因此会导致上传大文件时其他所有接口都被阻塞的问题，
## 参考
fastapi 这种问题的介绍可以参考 https://github.com/zhanymkanov/fastapi-best-practices#7-dont-make-your-routes-async-if-you-have-only-blocking-io-operations
<img width="980" alt="image" src="https://github.com/chatchat-space/Langchain-Chatchat/assets/30254092/2b99c9e6-e449-41a8-87a7-bf592e44104b">

## 解决方式
通过修改为同步方式定义路由函数解决
