### PR TITLE
fix(pgvector): fix Collection not found error

### DIFF
--- a/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/server/knowledge_base/kb_service/pg_kb_service.py
@@ -73,6 +73,10 @@ class PGKBService(KBService):
     def do_clear_vs(self):
         self.pg_vector.delete_collection()
 
+        # langchain.vectorstores.PGVector always assumes that the collection exists. So after deleting the collection,
+        # we should recreate it to avoid errors.
+        self.pg_vector.create_collection()
+
 
 if __name__ == '__main__':
     from server.db.base import Base, engine


### PR DESCRIPTION
When doing `python init_database.py --recreate-vs` with pgvector as vector store. it would occur "Collection not found error". And all existing kb docs would not be added to pgvector.

This is happened because when recreating vs, kb.clear_vs() would be called to do cleaning. At this time, collection is deleted. It will not be created automatically.

Fix this by re-creating the collection manually just after deleting it.

Fixes: #1288