### PR TITLE
fix api and webui:  优化知识库问答与搜索引擎问答的API接口，避免docs重复返回(close #1431)

### DIFF
--- a/server/chat/knowledge_base_chat.py
+++ b/server/chat/knowledge_base_chat.py
@@ -86,9 +86,8 @@ async def knowledge_base_chat(query: str = Body(..., description="用户输入",
         if stream:
             async for token in callback.aiter():
                 # Use server-sent-events to stream the response
-                yield json.dumps({"answer": token,
-                                  "docs": source_documents},
-                                 ensure_ascii=False)
+                yield json.dumps({"answer": token}, ensure_ascii=False)
+            yield json.dumps({"docs": source_documents}, ensure_ascii=False)
         else:
             answer = ""
             async for token in callback.aiter():

--- a/server/chat/search_engine_chat.py
+++ b/server/chat/search_engine_chat.py
@@ -121,9 +121,8 @@ async def search_engine_chat(query: str = Body(..., description="用户输入", 
         if stream:
             async for token in callback.aiter():
                 # Use server-sent-events to stream the response
-                yield json.dumps({"answer": token,
-                                  "docs": source_documents},
-                                 ensure_ascii=False)
+                yield json.dumps({"answer": token}, ensure_ascii=False)
+            yield json.dumps({"docs": source_documents}, ensure_ascii=False)
         else:
             answer = ""
             async for token in callback.aiter():

--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -25,7 +25,6 @@ from server.knowledge_base.utils import (
     list_kbs_from_folder, list_files_from_folder,
 )
 from server.utils import embedding_device
-from typing import List, Union, Dict
 from typing import List, Union, Dict, Optional
 
 

--- a/server/llm_api.py
+++ b/server/llm_api.py
@@ -5,7 +5,8 @@ import httpx
 
 
 def list_llm_models(
-    controller_address: str = Body(None, description="Fastchat controller服务器地址", examples=[fschat_controller_address()])
+    controller_address: str = Body(None, description="Fastchat controller服务器地址", examples=[fschat_controller_address()]),
+    placeholder: str = Body(None, description="该参数未使用，占位用"),
 ) -> BaseResponse:
     '''
     从fastchat controller获取已加载模型列表

--- a/startup.py
+++ b/startup.py
@@ -18,7 +18,7 @@ except:
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from configs.model_config import EMBEDDING_MODEL, llm_model_dict, LLM_MODEL, LOG_PATH, \
-    logger
+    logger, log_verbose
 from configs.server_config import (WEBUI_SERVER, API_SERVER, FSCHAT_CONTROLLER,
                                    FSCHAT_OPENAI_API, HTTPX_DEFAULT_TIMEOUT)
 from server.utils import (fschat_controller_address, fschat_model_worker_address,
@@ -536,7 +536,7 @@ async def start_main_server():
     def process_count():
         return len(processes) + len(processes["online_api"]) + len(processes["model_worker"]) - 2
 
-    if args.quiet:
+    if args.quiet or not log_verbose:
         log_level = "ERROR"
     else:
         log_level = "INFO"


### PR DESCRIPTION
1. fix #1431: 优化知识库问答与搜索引擎问答的API接口，避免docs重复返回
2. startup.py根据configs.log_verbose控制log级别
3. 修复/llm_model/list_models的bug: 只有一个参数时，fastapi未返回json导致视图函数出错