### PR TITLE
将所有httpx请求改为使用Client，提高效率，方便以后设置代理等。

### DIFF
--- a/server/model_workers/minimax.py
+++ b/server/model_workers/minimax.py
@@ -2,7 +2,7 @@ from server.model_workers.base import ApiModelWorker
 from fastchat import conversation as conv
 import sys
 import json
-import httpx
+from server.utils import get_httpx_client
 from pprint import pprint
 from typing import List, Dict
 
@@ -63,22 +63,23 @@ class MiniMaxWorker(ApiModelWorker):
         }
         print("request data sent to minimax:")
         pprint(data)
-        response = httpx.stream("POST",
-                                self.BASE_URL.format(pro=pro, group_id=group_id),
-                                headers=headers,
-                                json=data)
-        with response as r:
-            text = ""
-            for e in r.iter_text():
-                if e.startswith("data: "): # 真是优秀的返回
-                    data = json.loads(e[6:])
-                    if not data.get("usage"):
-                        if choices := data.get("choices"):
-                            chunk = choices[0].get("delta", "").strip()
-                            if chunk:
-                                print(chunk)
-                                text += chunk
-                                yield json.dumps({"error_code": 0, "text": text}, ensure_ascii=False).encode() + b"\0"
+        with get_httpx_client() as client:
+            response = client.stream("POST",
+                                    self.BASE_URL.format(pro=pro, group_id=group_id),
+                                    headers=headers,
+                                    json=data)
+            with response as r:
+                text = ""
+                for e in r.iter_text():
+                    if e.startswith("data: "): # 真是优秀的返回
+                        data = json.loads(e[6:])
+                        if not data.get("usage"):
+                            if choices := data.get("choices"):
+                                chunk = choices[0].get("delta", "").strip()
+                                if chunk:
+                                    print(chunk)
+                                    text += chunk
+                                    yield json.dumps({"error_code": 0, "text": text}, ensure_ascii=False).encode() + b"\0"
     
     def get_embeddings(self, params):
         # TODO: 支持embeddings

--- a/server/model_workers/qianfan.py
+++ b/server/model_workers/qianfan.py
@@ -5,7 +5,7 @@ import sys
 import json
 import httpx
 from cachetools import cached, TTLCache
-from server.utils import get_model_worker_config
+from server.utils import get_model_worker_config, get_httpx_client
 from typing import List, Literal, Dict
 
 
@@ -54,7 +54,8 @@ def get_baidu_access_token(api_key: str, secret_key: str) -> str:
     url = "https://aip.baidubce.com/oauth/2.0/token"
     params = {"grant_type": "client_credentials", "client_id": api_key, "client_secret": secret_key}
     try:
-        return httpx.get(url, params=params).json().get("access_token")
+        with get_httpx_client() as client:
+            return client.get(url, params=params).json().get("access_token")
     except Exception as e:
         print(f"failed to get token from baidu: {e}")
 
@@ -91,14 +92,15 @@ def request_qianfan_api(
         'Accept': 'application/json',
     }
 
-    with httpx.stream("POST", url, headers=headers, json=payload) as response:
-        for line in response.iter_lines():
-            if not line.strip():
-                continue
-            if line.startswith("data: "):
-                line = line[6:]
-            resp = json.loads(line)
-            yield resp
+    with get_httpx_client() as client:
+        with client.stream("POST", url, headers=headers, json=payload) as response:
+            for line in response.iter_lines():
+                if not line.strip():
+                    continue
+                if line.startswith("data: "):
+                    line = line[6:]
+                resp = json.loads(line)
+                yield resp
 
 
 class QianFanWorker(ApiModelWorker):


### PR DESCRIPTION
- 将所有httpx请求改为使用Client，提高效率，方便以后设置代理等。
- 将本项目相关服务加入无代理列表，避免fastchat的服务器请求错误。(windows下无效)