### PR TITLE
修复webui中重建知识库以及对话界面UI错误

### DIFF
--- a/server/knowledge_base/migrate.py
+++ b/server/knowledge_base/migrate.py
@@ -1,4 +1,5 @@
 from configs import (EMBEDDING_MODEL, DEFAULT_VS_TYPE, ZH_TITLE_ENHANCE,
+                     CHUNK_SIZE, OVERLAP_SIZE,
                     logger, log_verbose)
 from server.knowledge_base.utils import (get_file_path, list_kbs_from_folder,
                                         list_files_from_folder,files2docs_in_thread,

--- a/server/knowledge_base/utils.py
+++ b/server/knowledge_base/utils.py
@@ -373,18 +373,23 @@ def files2docs_in_thread(
     kwargs_list = []
     for i, file in enumerate(files):
         kwargs = {}
-        if isinstance(file, tuple) and len(file) >= 2:
-            file = KnowledgeFile(filename=file[0], knowledge_base_name=file[1])
-        elif isinstance(file, dict):
-            filename = file.pop("filename")
-            kb_name = file.pop("kb_name")
-            kwargs = file
-            file = KnowledgeFile(filename=filename, knowledge_base_name=kb_name)
-        kwargs["file"] = file
-        kwargs["chunk_size"] = chunk_size
-        kwargs["chunk_overlap"] = chunk_overlap
-        kwargs["zh_title_enhance"] = zh_title_enhance
-        kwargs_list.append(kwargs)
+        try:
+            if isinstance(file, tuple) and len(file) >= 2:
+                filename=file[0]
+                kb_name=file[1]
+                file = KnowledgeFile(filename=filename, knowledge_base_name=kb_name)
+            elif isinstance(file, dict):
+                filename = file.pop("filename")
+                kb_name = file.pop("kb_name")
+                kwargs.update(file)
+                file = KnowledgeFile(filename=filename, knowledge_base_name=kb_name)
+            kwargs["file"] = file
+            kwargs["chunk_size"] = chunk_size
+            kwargs["chunk_overlap"] = chunk_overlap
+            kwargs["zh_title_enhance"] = zh_title_enhance
+            kwargs_list.append(kwargs)
+        except Exception as e:
+            yield False, (kb_name, filename, str(e))
 
     for result in run_in_thread_pool(func=file2docs, params=kwargs_list, pool=pool):
         yield result

--- a/tests/api/test_stream_chat_api.py
+++ b/tests/api/test_stream_chat_api.py
@@ -91,7 +91,7 @@ def test_knowledge_chat(api="/chat/knowledge_base_chat"):
     print("=" * 30 + api + "  output" + "="*30)
     for line in response.iter_content(None, decode_unicode=True):
         data = json.loads(line)
-        if "anser" in data:
+        if "answer" in data:
             print(data["answer"], end="", flush=True)
     assert "docs" in data and len(data["docs"]) > 0
     pprint(data["docs"])


### PR DESCRIPTION
修复bug:
- webui点重建知识库时，如果存在不支持的文件会导致整个接口错误;
- migrate中没有导入CHUNK_SIZE、OVERLAP_SIZE参数
- webui对话界面的expander一直为running状态；
- 简化历史消息获取方法