### PR TITLE
feat: 增加completion功能的API接口，暂不支持online_api模型

### DIFF
--- a/configs/prompt_config.py.example
+++ b/configs/prompt_config.py.example
@@ -19,6 +19,10 @@
 
 PROMPT_TEMPLATES = {}
 
+PROMPT_TEMPLATES["completion"] = {
+    "default": "{input}"
+}
+
 PROMPT_TEMPLATES["llm_chat"] = {
     "default": "{{ input }}",
 

--- a/server/api.py
+++ b/server/api.py
@@ -11,7 +11,7 @@ import argparse
 import uvicorn
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import RedirectResponse
-from server.chat import (chat, knowledge_base_chat, openai_chat,
+from server.chat import (completion,chat, knowledge_base_chat, openai_chat,
                          search_engine_chat, agent_chat)
 from server.knowledge_base.kb_api import list_kbs, create_kb, delete_kb
 from server.knowledge_base.kb_doc_api import (list_files, upload_docs, delete_docs,
@@ -51,6 +51,10 @@ def create_app():
     app.get("/",
             response_model=BaseResponse,
             summary="swagger 文档")(document)
+
+    app.post("/completion",
+             tags=["Completion"],
+             summary="要求llm模型补全(通过LLMChain)")(completion)
 
     # Tag: Chat
     app.post("/chat/fastchat",

--- a/server/chat/__init__.py
+++ b/server/chat/__init__.py
@@ -1,4 +1,5 @@
 from .chat import chat
+from .completion import completion
 from .knowledge_base_chat import knowledge_base_chat
 from .openai_chat import openai_chat
 from .search_engine_chat import search_engine_chat

--- a/server/chat/completion.py
+++ b/server/chat/completion.py
@@ -1,0 +1,64 @@
+from fastapi import Body
+from fastapi.responses import StreamingResponse
+from configs import LLM_MODEL, TEMPERATURE
+from server.utils import wrap_done, get_OpenAI
+from langchain.chains import LLMChain
+from langchain.callbacks import AsyncIteratorCallbackHandler
+from typing import AsyncIterable
+import asyncio
+from langchain.prompts.chat import PromptTemplate
+from server.utils import get_prompt_template
+
+
+async def completion(query: str = Body(..., description="用户输入", examples=["恼羞成怒"]),
+                     stream: bool = Body(False, description="流式输出"),
+                     echo: bool = Body(False, description="除了输出之外，还回显输入"),
+                     model_name: str = Body(LLM_MODEL, description="LLM 模型名称。"),
+                     temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=1.0),
+                     max_tokens: int = Body(1024, description="限制LLM生成Token数量，默认None代表模型最大值"),
+                     # top_p: float = Body(TOP_P, description="LLM 核采样。勿与temperature同时设置", gt=0.0, lt=1.0),
+                     prompt_name: str = Body("default",
+                                             description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
+                     ):
+
+    #todo 因ApiModelWorker 默认是按chat处理的，会对params["prompt"] 解析为messages，因此ApiModelWorker 使用时需要有相应处理
+    async def completion_iterator(query: str,
+                                  model_name: str = LLM_MODEL,
+                                  prompt_name: str = prompt_name,
+                                  echo: bool = echo,
+                                  ) -> AsyncIterable[str]:
+        callback = AsyncIteratorCallbackHandler()
+        model = get_OpenAI(
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            callbacks=[callback],
+            echo=echo
+        )
+
+        prompt_template = get_prompt_template("completion", prompt_name)
+        prompt = PromptTemplate.from_template(prompt_template)
+        chain = LLMChain(prompt=prompt, llm=model)
+
+        # Begin a task that runs in the background.
+        task = asyncio.create_task(wrap_done(
+            chain.acall({"input": query}),
+            callback.done),
+        )
+
+        if stream:
+            async for token in callback.aiter():
+                # Use server-sent-events to stream the response
+                yield token
+        else:
+            answer = ""
+            async for token in callback.aiter():
+                answer += token
+            yield answer
+
+        await task
+
+    return StreamingResponse(completion_iterator(query=query,
+                                                 model_name=model_name,
+                                                 prompt_name=prompt_name),
+                             media_type="text/event-stream")


### PR DESCRIPTION
项目中使用langchain-chatchat作为骨架，因为部分场景不需要支持聊天，只需completion即可，且用到了completion 的echo参数，因此加了一个completion 接口。这样聊天、非聊天场景均可以使用langchain-chatchat，且未来可以扩展支持将聊天记录持久化地到db中，并记录用户对llm响应的反馈。

`python startup.py --all-api` 启动后，即可访问

```
curl --location 'http://localhost:7861/completion' \
--header 'Content-Type: application/json' \
--data '{
    "query": "天为什么是蓝的"
}'
```