### PR TITLE
修复代理no_proxy格式问题

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -596,7 +596,7 @@ def get_httpx_client(
     })
     for host in os.environ.get("no_proxy", "").split(","):
         if host := host.strip():
-            default_proxies.update({host: None})
+            default_proxies.update({'all://' + host: None})
 
     # merge default proxies with user provided proxies
     if isinstance(proxies, str):


### PR DESCRIPTION
修复可能出现的“ValueError Proxy keys should use proper URL forms rather than plain scheme strings.”错误

