### PR TITLE
修订：文档的索引支持，基于可选的配置文件为知识库问答提供简单的强制索引功能

### DIFF
--- a/configs/kb_config.py.example
+++ b/configs/kb_config.py.example
@@ -6,6 +6,22 @@ DEFAULT_KNOWLEDGE_BASE = "samples"
 # 默认向量库类型。可选：faiss, milvus(离线) & zilliz(在线), pg.
 DEFAULT_VS_TYPE = "faiss"
 
+# 使用索引(目前仅支持faiss, pg, 可不填，默认为False)
+USE_KB_INDEX = True
+
+# 索引格式配置(可不填, 当且仅当USE_KB_INDEX = True 且此项配置后尝试获取)
+# 如果使用索引，在导入文档时，将根据文档名称自动创建索引，同时在知识库对话页面中也会给出空的索引示例。
+# 例如索引名称格式为：{machine_name}_AA{machine_model}-Bcd_{produce_date}
+# 程序通过正则表达式识别{}中的内容作为索引名称，并将"}"与"{"之间的字符串内容作为识别文件名时的分隔符。
+# 对于文件/data/example/测试机器名称__AA测试机器型号-Bcd_2021-01-01.txt
+# 将会建立如下索引：
+# machine_name=测试机器名称_
+# machine_model=测试机器型号
+# produce_date=2023-01-01
+# 在实际查询时，想要根据指定的机器的指定型号进行回答，那么在页面填入指定的索引JSON即可。
+# 这将极大增强本地化知识库的准确率。
+KB_INDEX_PATTERN = "{machine_name}_AA{machine_model}-Bcd_{produce_date}"
+
 # 缓存向量库数量（针对FAISS）
 CACHED_VS_NUM = 1
 

--- a/server/chat/knowledge_base_chat.py
+++ b/server/chat/knowledge_base_chat.py
@@ -5,7 +5,7 @@ from server.utils import wrap_done, get_ChatOpenAI
 from server.utils import BaseResponse, get_prompt_template
 from langchain.chains import LLMChain
 from langchain.callbacks import AsyncIteratorCallbackHandler
-from typing import AsyncIterable, List, Optional
+from typing import AsyncIterable, List, Optional, Dict
 import asyncio
 from langchain.prompts.chat import ChatPromptTemplate
 from server.chat.utils import History
@@ -35,6 +35,7 @@ async def knowledge_base_chat(query: str = Body(..., description="用户输入",
                             max_tokens: Optional[int] = Body(None, description="限制LLM生成Token数量，默认None代表模型最大值"),
                             prompt_name: str = Body("default", description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
                             request: Request = None,
+                            kb_index: Dict = None,
                         ):
     kb = KBServiceFactory.get_service_by_name(knowledge_base_name)
     if kb is None:
@@ -55,7 +56,7 @@ async def knowledge_base_chat(query: str = Body(..., description="用户输入",
             max_tokens=max_tokens,
             callbacks=[callback],
         )
-        docs = search_docs(query, knowledge_base_name, top_k, score_threshold)
+        docs = search_docs(query, knowledge_base_name, top_k, score_threshold, kb_index)
         context = "\n".join([doc.page_content for doc in docs])
         if len(docs) == 0: ## 如果没有找到相关文档，使用Empty模板
             prompt_template = get_prompt_template("knowledge_base_chat", "Empty")

--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -25,11 +25,12 @@ def search_docs(query: str = Body(..., description="用户输入", examples=["�
                 knowledge_base_name: str = Body(..., description="知识库名称", examples=["samples"]),
                 top_k: int = Body(VECTOR_SEARCH_TOP_K, description="匹配向量数"),
                 score_threshold: float = Body(SCORE_THRESHOLD, description="知识库匹配相关度阈值，取值范围在0-1之间，SCORE越小，相关度越高，取到1相当于不筛选，建议设置在0.5左右", ge=0, le=1),
+                kb_index: Dict = None,
                 ) -> List[DocumentWithScore]:
     kb = KBServiceFactory.get_service_by_name(knowledge_base_name)
     if kb is None:
         return []
-    docs = kb.search_docs(query, top_k, score_threshold)
+    docs = kb.search_docs(query, top_k, score_threshold, kb_index=kb_index)
     data = [DocumentWithScore(**x[0].dict(), score=x[1]) for x in docs]
     return data
 

--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -167,8 +167,9 @@ class KBService(ABC):
                     query: str,
                     top_k: int = VECTOR_SEARCH_TOP_K,
                     score_threshold: float = SCORE_THRESHOLD,
+                    kb_index: Dict = None,
                     ):
-        docs = self.do_search(query, top_k, score_threshold)
+        docs = self.do_search(query, top_k, score_threshold, kb_index)
         return docs
 
     def get_doc_by_id(self, id: str) -> Optional[Document]:
@@ -221,6 +222,7 @@ class KBService(ABC):
                   query: str,
                   top_k: int,
                   score_threshold: float,
+                  kb_index: Dict = None,
                   ) -> List[Document]:
         """
         搜索知识库子类实自己逻辑

--- a/server/knowledge_base/kb_service/default_kb_service.py
+++ b/server/knowledge_base/kb_service/default_kb_service.py
@@ -25,7 +25,7 @@ class DefaultKBService(KBService):
     def do_init(self):
         pass
 
-    def do_search(self):
+    def do_search(self, kb_index=None):
         pass
 
     def do_insert_multi_knowledge(self):

--- a/server/knowledge_base/kb_service/faiss_kb_service.py
+++ b/server/knowledge_base/kb_service/faiss_kb_service.py
@@ -50,15 +50,14 @@ class FaissKBService(KBService):
         self.clear_vs()
         shutil.rmtree(self.kb_path)
 
-    def do_search(self,
-                  query: str,
-                  top_k: int,
-                  score_threshold: float = SCORE_THRESHOLD,
-                  ) -> List[Document]:
+    def do_search(self, query: str, top_k: int, score_threshold: float, kb_index=None) -> List[Document]:
         embed_func = EmbeddingsFunAdapter(self.embed_model)
         embeddings = embed_func.embed_query(query)
         with self.load_vector_store().acquire() as vs:
-            docs = vs.similarity_search_with_score_by_vector(embeddings, k=top_k, score_threshold=score_threshold)
+            if kb_index:
+                docs = vs.similarity_search_with_score_by_vector(embeddings, k=top_k, score_threshold=score_threshold, filter=kb_index)
+            else:
+                docs = vs.similarity_search_with_score_by_vector(embeddings, k=top_k, score_threshold=score_threshold)
         return docs
 
     def do_add_doc(self,

--- a/server/knowledge_base/kb_service/milvus_kb_service.py
+++ b/server/knowledge_base/kb_service/milvus_kb_service.py
@@ -57,11 +57,12 @@ class MilvusKBService(KBService):
             self.milvus.col.release()
             self.milvus.col.drop()
 
-    def do_search(self, query: str, top_k: int, score_threshold: float):
+    def do_search(self, query: str, top_k: int, score_threshold: float, kb_index=None):
         self._load_milvus()
         embed_func = EmbeddingsFunAdapter(self.embed_model)
         embeddings = embed_func.embed_query(query)
-        docs = self.milvus.similarity_search_with_score_by_vector(embeddings, top_k)
+        # TODO: add metadata index support by parameter 'kb_index'
+        docs = self.milvus.similarity_search_with_score_by_vector(embeddings, top_k, )
         return score_threshold_process(score_threshold, top_k, docs)
 
     def do_add_doc(self, docs: List[Document], **kwargs) -> List[Dict]:

--- a/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/server/knowledge_base/kb_service/pg_kb_service.py
@@ -51,11 +51,16 @@ class PGKBService(KBService):
             '''))
             connect.commit()
 
-    def do_search(self, query: str, top_k: int, score_threshold: float):
+    def do_search(self, query: str, top_k: int, score_threshold: float, kb_index=None):
         self._load_pg_vector()
         embed_func = EmbeddingsFunAdapter(self.embed_model)
         embeddings = embed_func.embed_query(query)
-        docs = self.pg_vector.similarity_search_with_score_by_vector(embeddings, top_k)
+        if kb_index:
+            # TODO 仅对filter传入dict参数，暂未测试
+            # docs = self.pg_vector.similarity_search_with_score_by_vector(embeddings, top_k, filter=kb_index)
+            docs = self.pg_vector.similarity_search_with_score_by_vector(embeddings, top_k)
+        else:
+            docs = self.pg_vector.similarity_search_with_score_by_vector(embeddings, top_k)
         return score_threshold_process(score_threshold, top_k, docs)
 
     def do_add_doc(self, docs: List[Document], **kwargs) -> List[Dict]:

--- a/server/knowledge_base/kb_service/zilliz_kb_service.py
+++ b/server/knowledge_base/kb_service/zilliz_kb_service.py
@@ -57,11 +57,16 @@ class ZillizKBService(KBService):
             self.zilliz.col.release()
             self.zilliz.col.drop()
 
-    def do_search(self, query: str, top_k: int, score_threshold: float):
+    def do_search(self, query: str, top_k: int, score_threshold: float, kb_index=None):
         self._load_zilliz()
         embed_func = EmbeddingsFunAdapter(self.embed_model)
         embeddings = embed_func.embed_query(query)
-        docs = self.zilliz.similarity_search_with_score_by_vector(embeddings, top_k)
+        if kb_index:
+            # TODO cloud版zilliz与阿里云版配置不一样，加载失败，无法测试，仅将kb_index字典赋值给filter
+            # docs = self.zilliz.similarity_search_with_score_by_vector(embeddings, top_k, filter=kb_index)
+            docs = self.zilliz.similarity_search_with_score_by_vector(embeddings, top_k)
+        else:
+            docs = self.zilliz.similarity_search_with_score_by_vector(embeddings, top_k)
         return score_threshold_process(score_threshold, top_k, docs)
 
     def do_add_doc(self, docs: List[Document], **kwargs) -> List[Dict]:

--- a/server/knowledge_base/utils.py
+++ b/server/knowledge_base/utils.py
@@ -1,4 +1,6 @@
 import os
+import re
+
 from configs import (
     KB_ROOT_PATH,
     CHUNK_SIZE,
@@ -8,7 +10,7 @@ from configs import (
     log_verbose,
     text_splitter_dict,
     LLM_MODEL,
-    TEXT_SPLITTER_NAME,
+    TEXT_SPLITTER_NAME, kb_config,
 )
 import importlib
 from text_splitter import zh_title_enhance as func_zh_title_enhance
@@ -266,6 +268,43 @@ def make_text_splitter(
     return text_splitter
 
 
+def get_customized_index_dict(docs: list) -> list:
+    use_kb_index = getattr(kb_config, 'USE_KB_INDEX', False)
+    if not use_kb_index:
+        return docs
+
+    kb_index_pattern = getattr(kb_config, 'KB_INDEX_PATTERN', '{}')
+    normalized_splitter = "$$splitter$$"
+    placeholders = re.findall(r'\{([^}]+)\}', kb_index_pattern)
+    splitters = re.findall(r'\}([^}]+)\{', kb_index_pattern)
+
+    for doc in docs:
+        # 文件全路径
+        full_file_path = doc.metadata["source"]
+        # 抽取带后缀的文件名
+        file_name = os.path.basename(full_file_path)
+        # 去掉后缀
+        file_name = os.path.splitext(file_name)[0]
+
+        # 分隔符统一化
+        formatted_txt = file_name
+        if splitters:
+            for splitter in splitters:
+                formatted_txt = formatted_txt.replace(splitter, normalized_splitter)
+
+        # 拆分文件名并按照占位符加载
+        doc_index_dict = {}
+        try:
+            for i in range(len(formatted_txt.split(normalized_splitter))):
+                doc_index_dict[placeholders[i]] = formatted_txt.split(normalized_splitter)[i]
+        except Exception as e:
+            msg = f"从文件名 {file_name} 获取自定义索引时出错！：{e}"
+            logger.error(f'{e.__class__.__name__}: {msg}',
+                         exc_info=e if log_verbose else None)
+        doc.metadata.update(doc_index_dict)
+    return docs
+
+
 class KnowledgeFile:
     def __init__(
             self,
@@ -318,7 +357,10 @@ class KnowledgeFile:
             else:
                 docs = text_splitter.split_documents(docs)
 
-        print(f"文档切分示例：{docs[0]}")
+        # 装载自定义索引
+        docs = get_customized_index_dict(docs)
+        # 打印示例
+        print(f"文档切分示例：{docs[0]}\n索引示例：{docs[0].metadata}")
         if zh_title_enhance:
             docs = func_zh_title_enhance(docs)
         self.splited_docs = docs

--- a/webui_pages/utils.py
+++ b/webui_pages/utils.py
@@ -357,6 +357,7 @@ class ApiRequest:
         temperature: float = TEMPERATURE,
         max_tokens: int = None,
         prompt_name: str = "default",
+        kb_index: Dict = None,
     ):
         '''
         对应api.py/chat/knowledge_base_chat接口
@@ -372,6 +373,7 @@ class ApiRequest:
             "temperature": temperature,
             "max_tokens": max_tokens,
             "prompt_name": prompt_name,
+            "kb_index": kb_index,
         }
 
         print(f"received input message:")


### PR DESCRIPTION
对 #1565 的实现
通过在kb_config中设定可选的配置
即可实现从规范化的文件名中获取索引，在页面查询时将对应的索引内容输入到动态生成的页面上即可只查询索引给定的文本
这将极大改善原版master分支上同一款式不同型号的文章放在同一个知识库中导致无法查询特定型号的问题
至少在这个场景下，如果文本拆分器定义的好，回复准确率可以从`绝不可能回答正确`，提升到`80%以上`，并且能够保证 引用的文献一定出自索引指定的内容。
支持faiss并测试通过，其它向量仓库的实现因为dev分支实在是跑不通faiss之外的实现，因此注释掉了相关行，仍走无索引的方式。
faiss实现已经经过离线Baichuan2-13b-chat模型的私有知识库验证。