### PR TITLE
解决torch版本过高引起的模型加载报错的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 langchain>=0.0.319
 langchain-experimental>=0.0.30
-fschat[model_worker]==0.2.31
-xformers>=0.0.22.post4
+fschat[model_worker]
+xformers
 openai>=0.28.1
 sentence_transformers
 transformers>=4.34
-torch>=2.0.1 # 推荐2.1
+torch==2.0.1 
 torchvision
 torchaudio
 fastapi>=0.104


### PR DESCRIPTION
解决issue  https://github.com/chatchat-space/Langchain-Chatchat/issues/1904   中提到的**ERROR: KeyError: Caught exception: 'choices'** 问题。