### PR TITLE
bugfix:重建向量数据库时如果没有db表，使用文档的初始化方式必然报错

### DIFF
--- a/init_database.py
+++ b/init_database.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     start_time = datetime.now()
 
-    if args.create_tables:
+    if args.create_tables or args.recraete_vs:
         create_tables() # confirm tables exist
 
     if args.clear_tables:


### PR DESCRIPTION
复现方式，删除info.db，执行python init_database.py -r，必然报错