### PR TITLE
bugfix:dev分支创建知识库必然失败的bug修复

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -283,6 +283,8 @@ class KBServiceFactory:
                             default_embed_model: str = EMBEDDING_MODEL,
                             ) -> KBService:
         _, vs_type, embed_model = load_kb_from_db(kb_name)
+        if _ is None:  # kb not in db, just return None
+            return None
         if vs_type is None:  # faiss knowledge base not in db
             vs_type = default_vs_type
         if embed_model is None:

--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -278,17 +278,10 @@ class KBServiceFactory:
             return DefaultKBService(kb_name)
 
     @staticmethod
-    def get_service_by_name(kb_name: str,
-                            default_vs_type: SupportedVSType = SupportedVSType.FAISS,
-                            default_embed_model: str = EMBEDDING_MODEL,
-                            ) -> KBService:
+    def get_service_by_name(kb_name: str) -> KBService:
         _, vs_type, embed_model = load_kb_from_db(kb_name)
         if _ is None:  # kb not in db, just return None
             return None
-        if vs_type is None:  # faiss knowledge base not in db
-            vs_type = default_vs_type
-        if embed_model is None:
-            embed_model = default_embed_model
         return KBServiceFactory.get_service(kb_name, vs_type, embed_model)
 
     @staticmethod
@@ -333,6 +326,9 @@ def get_kb_details() -> List[Dict]:
 
 def get_kb_file_details(kb_name: str) -> List[Dict]:
     kb = KBServiceFactory.get_service_by_name(kb_name)
+    if kb is None:
+        return []
+
     files_in_folder = list_files_from_folder(kb_name)
     files_in_db = kb.list_files()
     result = {}

--- a/server/knowledge_base/migrate.py
+++ b/server/knowledge_base/migrate.py
@@ -152,7 +152,7 @@ def prune_db_docs(kb_names: List[str]):
     '''
     for kb_name in kb_names:
         kb = KBServiceFactory.get_service_by_name(kb_name)
-        if kb and kb.exists():
+        if kb is not None:
             files_in_db = kb.list_files()
             files_in_folder = list_files_from_folder(kb_name)
             files = list(set(files_in_db) - set(files_in_folder))
@@ -170,7 +170,7 @@ def prune_folder_files(kb_names: List[str]):
     '''
     for kb_name in kb_names:
         kb = KBServiceFactory.get_service_by_name(kb_name)
-        if kb and kb.exists():
+        if kb is not None:
             files_in_db = kb.list_files()
             files_in_folder = list_files_from_folder(kb_name)
             files = list(set(files_in_folder) - set(files_in_db))

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -33,7 +33,7 @@ def test_recreate_vs():
     folder2db([kb_name], "recreate_vs")
 
     kb = KBServiceFactory.get_service_by_name(kb_name)
-    assert kb.exists()
+    assert kb and kb.exists()
 
     files = kb.list_files()
     print(files)


### PR DESCRIPTION
#1977 无法重新打开
这里的复现方式：
成功启动后，在页面上创建全新的KB时必然失败
此处逻辑在查询DB无数据时，依然创建了一个新的假KB，完成后DB中没有数据，KB也没有数据
此问题与 #1976 无关，我已经将关于init_database.py脚本的PR关闭了