### PR TITLE
修复bug-删除pg知识库时没有删除知识库目录

### DIFF
--- a/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/server/knowledge_base/kb_service/pg_kb_service.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 from typing import List, Dict, Optional
 
 from langchain.embeddings.base import Embeddings
@@ -56,6 +57,7 @@ class PGKBService(KBService):
                     DELETE FROM langchain_pg_collection WHERE name = '{self.kb_name}';
             '''))
             connect.commit()
+        shutil.rmtree(self.kb_path)
 
     def do_search(self, query: str, top_k: int, score_threshold: float, embeddings: Embeddings):
         self._load_pg_vector(embeddings=embeddings)


### PR DESCRIPTION
修复bug：使用pg知识库时，删除知识库没有删除知识库目录，导致不能再创建相同名称的知识库