### PR TITLE
Fix HeaderParsingError bug for kb_doc_api request.

### DIFF
--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -327,7 +327,6 @@ def download_doc(
             return FileResponse(
                 path=kb_file.filepath,
                 filename=kb_file.filename,
-                media_type="multipart/form-data",
                 content_disposition_type=content_disposition_type,
             )
     except Exception as e:


### PR DESCRIPTION
When using `urllib3` to request `download_doc` api, it will get the exception below:
```
2023-11-23 20:38:26,521 - connectionpool.py[line:471] - WARNING: Failed to parse headers (url=http://0.0.0.0:7861/knowledge_base/download_doc?knowledge_base_name=new-db-test&file_name=%E8%AF%BE%E9%A2%983-%E9%A1%B9%E7%9B%AE%E7%BB%84%E7%BB%87%E5%AE%9E%E6%96%BD%E5%8D%8F%E8%AE%AE-%E4%B8%AD%E7%A7%91%E9%99%A2%E8%87%AA%E5%8A%A8%E5%8C%96%E6%89%80.pdf&preview=False): [NoBoundaryInMultipartDefect()], unparsed data: ''
Traceback (most recent call last):
  File "/home/sunyaqiang/anaconda3/envs/common/lib/python3.8/site-packages/urllib3/connectionpool.py", line 469, in _make_request
    assert_header_parsing(httplib_response.msg)
  File "/home/sunyaqiang/anaconda3/envs/common/lib/python3.8/site-packages/urllib3/util/response.py", line 91, in assert_header_parsing
    raise HeaderParsingError(defects=defects, unparsed_data=unparsed_data)
urllib3.exceptions.HeaderParsingError: [NoBoundaryInMultipartDefect()], unparsed data: ''
```
To avoid the exception, the server api should be changed.

This PR remove `media_type="multipart/form-data"` for `FileResponse` in `download_doc` function.

