### PR TITLE
修复openai-api和azure-api可能无法使用的bug

### DIFF
--- a/configs/model_config.py.example
+++ b/configs/model_config.py.example
@@ -45,6 +45,7 @@ ONLINE_LLM_MODEL = {
         "api_base_url": "https://api.openai.com/v1",
         "api_key": "",
         "openai_proxy": "",
+        "provider": "OpenaiWorker",
     },
 
     # 具体注册及api key获取请前往 http://open.bigmodel.cn
@@ -112,6 +113,7 @@ ONLINE_LLM_MODEL = {
         "resource_name": "",  # https://{resource_name}.openai.azure.com/openai/ 填写resource_name的部分，其他部分不要填写
         "api_version": "",  # API的版本，不是模型版本
         "api_key": "",
+        "api_type": "azure",
         "provider": "AzureWorker",
     },
 

--- a/configs/server_config.py.example
+++ b/configs/server_config.py.example
@@ -128,6 +128,9 @@ FSCHAT_MODEL_WORKERS = {
     "tiangong-api": {
         "port": 21009,
     },
+    "openai-api": {
+        "port": 21010,
+    },
 }
 
 # fastchat multi model worker server

--- a/server/model_workers/__init__.py
+++ b/server/model_workers/__init__.py
@@ -8,3 +8,4 @@ from .qwen import QwenWorker
 from .baichuan import BaiChuanWorker
 from .azure import AzureWorker
 from .tiangong import TianGongWorker
+from .chatgpt import OpenaiWorker

--- a/server/model_workers/chatgpt.py
+++ b/server/model_workers/chatgpt.py
@@ -1,0 +1,84 @@
+import sys
+from fastchat.conversation import Conversation
+from server.model_workers.base import *
+from server.utils import get_httpx_client
+from fastchat import conversation as conv
+import json
+from typing import List, Dict
+
+
+class OpenaiWorker(ApiModelWorker):
+    def __init__(
+            self,
+            *,
+            controller_addr: str,
+            worker_addr: str,
+            model_names: List[str] = ["openai-api"],
+            version: str = "gpt-3.5-turbo",
+            **kwargs,
+    ):
+        kwargs.update(model_names=model_names, controller_addr=controller_addr, worker_addr=worker_addr)
+        kwargs.setdefault("context_len", 16384) 
+        super().__init__(**kwargs)
+        self.version = version
+
+    def do_chat(self, params: ApiChatParams) -> Dict:
+        params.load_config(self.model_names[0])
+        data = dict(
+            messages=params.messages,
+            temperature=params.temperature,
+            max_tokens=params.max_tokens,
+            stream=True,
+        )
+        url = "https://api.openai.com/v1/chat/completions"
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'api-key': params.api_key,
+        }
+
+        text = ""
+        with get_httpx_client() as client:
+            with client.stream("POST", url, headers=headers, json=data) as response:
+                for line in response.iter_lines():
+                    if not line.strip() or "[DONE]" in line:
+                        continue
+                    if line.startswith("data: "):
+                        line = line[6:]
+                    resp = json.loads(line)
+                    if choices := resp["choices"]:
+                        if chunk := choices[0].get("delta", {}).get("content"):
+                            text += chunk
+                            yield {
+                                    "error_code": 0,
+                                    "text": text
+                                }
+
+    def get_embeddings(self, params):
+        # TODO: 支持embeddings
+        print("embedding")
+        print(params)
+
+    def make_conv_template(self, conv_template: str = None, model_path: str = None) -> Conversation:
+        return conv.Conversation(
+            name=self.model_names[0],
+            system_message="You are ChatGPT, a large language model trained by OpenAI.",
+            messages=[],
+            roles=["user", "assistant"],
+            sep="\n### ",
+            stop_str="###",
+        )
+
+
+if __name__ == "__main__":
+    import uvicorn
+    from server.utils import MakeFastAPIOffline
+    from fastchat.serve.base_model_worker import app
+
+    worker = OpenaiWorker(
+        controller_addr="http://127.0.0.1:20001",
+        worker_addr="http://127.0.0.1:21010",
+    )
+    sys.modules["fastchat.serve.model_worker"].worker = worker
+    MakeFastAPIOffline(app)
+    uvicorn.run(app, port=21010)


### PR DESCRIPTION
openai-api和azure-api在fastchat注册后，绕过fastchat框架，直接使用langchain的chat_models,解决openai-api和azure-api无法使用的bug。