### PR TITLE
添加初步的 Intel XPU 支持

### DIFF
--- a/configs/model_config.py.example
+++ b/configs/model_config.py.example
@@ -8,7 +8,7 @@ MODEL_ROOT_PATH = ""
 # 选用的 Embedding 名称
 EMBEDDING_MODEL = "bge-large-zh"
 
-# Embedding 模型运行设备。设为"auto"会自动检测，也可手动设定为"cuda","mps","cpu"其中之一。
+# Embedding 模型运行设备。设为"auto"会自动检测，也可手动设定为"cuda","mps","xpu","cpu"其中之一。
 EMBEDDING_DEVICE = "auto"
 
 # 如果需要在 EMBEDDING_MODEL 中增加自定义的关键字时配置
@@ -26,7 +26,7 @@ LLM_MODELS = ["chatglm3-6b", "zhipu-api", "openai-api"] # "Qwen-1_8B-Chat",
 # AgentLM模型的名称 (可以不指定，指定之后就锁定进入Agent之后的Chain的模型，不指定就是LLM_MODELS[0])
 Agent_MODEL = None
 
-# LLM 运行设备。设为"auto"会自动检测，也可手动设定为"cuda","mps","cpu"其中之一。
+# LLM 运行设备。设为"auto"会自动检测，也可手动设定为"cuda","mps","xpu","cpu"其中之一。
 LLM_DEVICE = "auto"
 
 # 历史对话轮数


### PR DESCRIPTION
`fastchat`本身支持Intel GPU，所以尝试着在这里添加了一下对它的支持。

使用`chatglm3-6b`在A770 16GB上测试通过，普通对话和知识库问答都正常。
由于`vllm`不支持Intel GPU，所以无法使用。

在安装完依赖之后，还需要手动安装：
```bash
python -m pip install torch==2.0.1a0 torchvision==0.15.2a0 intel-extension-for-pytorch==2.0.110+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/cn/
```

启动之前，需要确保已经安装了Intel oneAPI SDK 2023.2版本（目前ipex还不支持2024版本），并且加载环境变量：

```bash
source /opt/intel/oneapi/setvars.sh
```
