### PR TITLE
fix: prompt template name error in file_chat

### DIFF
--- a/server/chat/file_chat.py
+++ b/server/chat/file_chat.py
@@ -132,7 +132,7 @@ async def file_chat(query: str = Body(..., description="用户输入", examples=
 
         context = "\n".join([doc.page_content for doc in docs])
         if len(docs) == 0: ## 如果没有找到相关文档，使用Empty模板
-            prompt_template = get_prompt_template("knowledge_base_chat", "Empty")
+            prompt_template = get_prompt_template("knowledge_base_chat", "empty")
         else:
             prompt_template = get_prompt_template("knowledge_base_chat", prompt_name)
         input_msg = History(role="user", content=prompt_template).to_msg_template(False)


### PR DESCRIPTION
`configs/prompt_config.py.example` 中参考文档为空时的 prompt_template 改成了 "empty", file_chat 接口需要对应修改。（Close #2346 )