### PR TITLE
fixed 迭代器参数传递错误，知识库问答报错TypeError: unhashable type: 'list'

### DIFF
--- a/server/chat/knowledge_base_chat.py
+++ b/server/chat/knowledge_base_chat.py
@@ -57,7 +57,7 @@ async def knowledge_base_chat(query: str = Body(..., description="用户输入",
             query: str,
             top_k: int,
             history: Optional[List[History]],
-            model_name: str = LLM_MODELS[0],
+            model_name: str = model_name,
             prompt_name: str = prompt_name,
     ) -> AsyncIterable[str]:
         nonlocal max_tokens
@@ -119,4 +119,4 @@ async def knowledge_base_chat(query: str = Body(..., description="用户输入",
                              ensure_ascii=False)
         await task
 
-    return EventSourceResponse(knowledge_base_chat_iterator(query, kb, top_k, history))
+    return EventSourceResponse(knowledge_base_chat_iterator(query, top_k, history))


### PR DESCRIPTION
/server/chat/knowledge_base_chat.py下迭代器参数传递错误导致webui界面知识问答对话报错：API通信遇到错误：peer closed connection without sending complete message body (incomplete chunked read)。

后台异常信息为：TypeError: unhashable type: 'list'