### PR TITLE
处理API调用报错

### DIFF
--- a/server/chat/chat.py
+++ b/server/chat/chat.py
@@ -39,6 +39,7 @@ async def chat(query: str = Body(..., description="用户输入", examples=["恼
         callback = AsyncIteratorCallbackHandler()
         callbacks = [callback]
         memory = None
+        message_id = None
 
         if conversation_id:
             message_id = add_message_to_db(chat_type="llm_chat", query=query, conversation_id=conversation_id)


### PR DESCRIPTION
处理在不指定conversation_id时，出现`local variable 'message_id' referenced before assignment`