### PR TITLE
fix: automatically replace unsupported torch device

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -497,23 +497,39 @@ def set_httpx_config(
 
     # 自动检查torch可用的设备。分布式部署时，不运行LLM的机器上可以不装torch
 
+def is_mps_available():
+    import torch
+    return hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+
+def is_cuda_available():
+    import torch
+    return torch.cuda.is_available()
 
 def detect_device() -> Literal["cuda", "mps", "cpu"]:
     try:
-        import torch
-        if torch.cuda.is_available():
+        if is_cuda_available():
             return "cuda"
-        if torch.backends.mps.is_available():
+        if is_mps_available():
             return "mps"
     except:
         pass
     return "cpu"
 
-
 def llm_device(device: str = None) -> Literal["cuda", "mps", "cpu"]:
     device = device or LLM_DEVICE
+
+    # fallback to available device if specified device is not available
+    if device == 'cuda' and not is_cuda_available() and is_mps_available():
+        logging.warning("cuda is not available, fallback to mps")
+        return "mps"
+    if device == 'mps' and not is_mps_available() and is_cuda_available():
+        logging.warning("mps is not available, fallback to cuda")
+        return "cuda"
+
+    # auto detect device if not specified
     if device not in ["cuda", "mps", "cpu"]:
-        device = detect_device()
+        return detect_device()
+
     return device
 
 


### PR DESCRIPTION
Thank you for your hard work on this fantastic project!

I've been trying to run this project on a Mac Studio with an M2 chip. Following the README instructions, I completed database initialization, model downloading, and other setup steps. However, I encountered a startup failure when launching the service.

The error message indicated: `"raise AssertionError('Torch not compiled with CUDA enabled')"`. This is expected since I am using an M2 chip. Tracing the stack trace, I located the issue in the `server/utils.py` file, where the 'cuda' device is set:

```py
def get_model_worker_config(model_name: str = None) -> dict:
    from configs.model_config import ONLINE_LLM_MODEL, MODEL_PATH
    from configs.server_config import FSCHAT_MODEL_WORKERS
    from server import model_workers

    config = FSCHAT_MODEL_WORKERS.get("default", {}).copy()
    config.update(ONLINE_LLM_MODEL.get(model_name, {}).copy())
    config.update(FSCHAT_MODEL_WORKERS.get(model_name, {}).copy()) # device: 'cuda' loaded here

    if model_name in ONLINE_LLM_MODEL:
    # ...

    if model_name in MODEL_PATH["llm_model"]:
    # ...
        config["device"] = llm_device(config.get("device"))
    return config
```

In `configs/server_config.py`, the 'cuda' device is explicitly set:

```py
FSCHAT_MODEL_WORKERS = {
  # ...

    "chatglm3-6b": {
        "device": "cuda", # here
    },

  # ...
}
```

Although the current code supports multiple platforms, this 'cuda' setting is not suitable for users with Apple chips. To enhance the robustness of the project and ensure smooth initial startup for Apple chip users with chatglm3-6b, I suggest adding smarter device detection and fallback logic. When the selected device is not supported, the system should automatically switch to other viable options, such as falling back from 'cuda' to 'mps'.