### PR TITLE
fix: ApiRequest.agent_chat 应当返回 dict 而非 str

### DIFF
--- a/webui_pages/utils.py
+++ b/webui_pages/utils.py
@@ -320,7 +320,7 @@ class ApiRequest:
         # pprint(data)
 
         response = self.post("/chat/agent_chat", json=data, stream=True)
-        return self._httpx_stream2generator(response)
+        return self._httpx_stream2generator(response, as_json=True)
 
     def knowledge_base_chat(
         self,


### PR DESCRIPTION
该问题会导致 WEBUI Agent对话出错。