### PR TITLE
fix: make_text_splitter use wrong chunk_* parameters when exception.

### DIFF
--- a/server/knowledge_base/utils.py
+++ b/server/knowledge_base/utils.py
@@ -258,7 +258,7 @@ def make_text_splitter(
         print(e)
         text_splitter_module = importlib.import_module('langchain.text_splitter')
         TextSplitter = getattr(text_splitter_module, "RecursiveCharacterTextSplitter")
-        text_splitter = TextSplitter(chunk_size=250, chunk_overlap=50)
+        text_splitter = TextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
     return text_splitter
 
 


### PR DESCRIPTION
…(close #2561)