### PR TITLE
修复使用Milvus存储，在点击知识库中文件信息的时候报错value ''xxx'' in list cannot be casted to Int64)的异常

### DIFF
--- a/server/knowledge_base/kb_service/milvus_kb_service.py
+++ b/server/knowledge_base/kb_service/milvus_kb_service.py
@@ -22,10 +22,14 @@ class MilvusKBService(KBService):
     #     if self.milvus.col:
     #         self.milvus.col.flush()
 
-    def get_doc_by_ids(self, ids: List[str]) -> List[Document]:
+    def get_doc_by_ids(self, ids: List[int]) -> List[Document]:
         result = []
         if self.milvus.col:
-            data_list = self.milvus.col.query(expr=f'pk in {ids}', output_fields=["*"])
+
+            # 使用整数形式的 ids 进行查询
+            int_ids = [int(id) for id in ids]
+
+            data_list = self.milvus.col.query(expr=f'pk in {int_ids}', output_fields=["*"])
             for data in data_list:
                 text = data.pop("text")
                 result.append(Document(page_content=text, metadata=data))

--- a/server/knowledge_base/kb_service/milvus_kb_service.py
+++ b/server/knowledge_base/kb_service/milvus_kb_service.py
@@ -22,7 +22,7 @@ class MilvusKBService(KBService):
     #     if self.milvus.col:
     #         self.milvus.col.flush()
 
-    def get_doc_by_ids(self, ids: List[int]) -> List[Document]:
+    def get_doc_by_ids(self, ids: List[str]) -> List[Document]:
         result = []
         if self.milvus.col:
 


### PR DESCRIPTION
**背景**：python3.9环境，master分支，使用pip install -r requirements_lite.txt安装依赖后，通过python startup.py -a --lite启动ChatChat。
**问题**：使用Milvus作为向量数据库，在向向量数据库中填充数据后，在查看数据时，会报错：
![image (1)](https://github.com/chatchat-space/Langchain-Chatchat/assets/10568269/e6072b86-0896-40fb-86cb-e10173276c94)

查看代码后发现sqlite数据库中的doc_id类型为字符串类型，但是Milvus的查询语句中需要的是int类型，所以导致报错，因此在使用doc_id进行查询前，需要先把doc_id的类型修改为int类型。
**异常堆栈**：
INFO:     127.0.0.1:59700 - "POST /knowledge_base/search_docs HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/uvicorn/protocols/http/httptools_impl.py", line 419, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/applications.py", line 116, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/_exception_handler.py", line 55, in wrapped_app
    raise exc
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/_exception_handler.py", line 44, in wrapped_app
    await app(scope, receive, sender)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/routing.py", line 746, in __call__
    await route.handle(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/routing.py", line 75, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/_exception_handler.py", line 55, in wrapped_app
    raise exc
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/_exception_handler.py", line 44, in wrapped_app
    await app(scope, receive, sender)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/routing.py", line 70, in app
    response = await func(request)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/fastapi/routing.py", line 299, in app
    raise e
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/fastapi/routing.py", line 294, in app
    raw_response = await run_endpoint_function(
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/fastapi/routing.py", line 193, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/starlette/concurrency.py", line 35, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 2134, in run_sync_in_worker_thread
    return await future
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 851, in run
    result = context.run(func, *args)
  File "/home/xxx/Documents/chatchat/Langchain-Chatchat/server/knowledge_base/kb_doc_api.py", line 41, in search_docs
    data = kb.list_docs(file_name=file_name, metadata=metadata)
  File "/home/xxx/Documents/chatchat/Langchain-Chatchat/server/knowledge_base/kb_service/base.py", line 214, in list_docs
    doc_info = self.get_doc_by_ids([x["id"]])[0]
  File "/home/xxx/Documents/chatchat/Langchain-Chatchat/server/knowledge_base/kb_service/milvus_kb_service.py", line 28, in get_doc_by_ids
    data_list = self.milvus.col.query(expr=f'pk in {ids}', output_fields=["*"])
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/orm/collection.py", line 925, in query
    return conn.query(
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/decorators.py", line 135, in handler
    raise e from e
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/decorators.py", line 131, in handler
    return func(*args, **kwargs)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/decorators.py", line 170, in handler
    return func(self, *args, **kwargs)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/decorators.py", line 110, in handler
    raise e from e
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/decorators.py", line 74, in handler
    return func(*args, **kwargs)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/client/grpc_handler.py", line 1330, in query
    check_status(response.status)
  File "/home/xxx/anaconda3/envs/chatchat/lib/python3.9/site-packages/pymilvus/client/utils.py", line 54, in check_status
    raise MilvusException(status.code, status.reason, status.error_code)
**pymilvus.exceptions.MilvusException: <MilvusException: (code=65535, message=cannot parse expression: pk in ['447088899605816486'], error: value ''447088899605816486'' in list cannot be casted to Int64)>**