### PR TITLE
fix embed_query return wrong embeddings

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -423,9 +423,7 @@ class EmbeddingsFunAdapter(Embeddings):
     def embed_query(self, text: str) -> List[float]:
         embeddings = embed_texts(texts=[text], embed_model=self.embed_model, to_query=True).data
         query_embed = embeddings[0]
-        query_embed_2d = np.reshape(query_embed, (1, -1))  # 将一维数组转换为二维数组
-        normalized_query_embed = normalize(query_embed_2d)
-        return normalized_query_embed[0].tolist()  # 将结果转换为一维数组并返回
+        return query_embed
 
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         embeddings = (await aembed_texts(texts=texts, embed_model=self.embed_model, to_query=False)).data


### PR DESCRIPTION
我用的是m3e-base embeddings model，在`embed_query`方法里，model返回的embeddings，被下面的np等方法转换了一下，在我这里会导致，查询出来的结果很不准。


下图是验证转换前后的embeddings内容：可以看到转换后的完全和embeddings model返回的完全不一样了。

<img width="1357" alt="image" src="https://github.com/chatchat-space/Langchain-Chatchat/assets/115431886/31e72a6b-87b9-401c-af76-65db1718ecf3">
