### PR TITLE
fix bugs of pg vector library

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -211,7 +211,10 @@ class KBService(ABC):
         doc_infos = list_docs_from_db(kb_name=self.kb_name, file_name=file_name, metadata=metadata)
         docs = []
         for x in doc_infos:
-            doc_info = self.get_doc_by_ids([x["id"]])[0]
+            infos = self.get_doc_by_ids([x["id"]])
+            if len(infos) == 0:
+                continue
+            doc_info = infos[0]
             if doc_info is not None:
                 # 处理非空的情况
                 doc_with_id = DocumentWithVSId(**doc_info.dict(), id=x["id"])

--- a/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/server/knowledge_base/kb_service/pg_kb_service.py
@@ -27,6 +27,7 @@ class PGKBService(KBService):
                                   connection_string=kbs_config.get("pg").get("connection_uri"))
 
     def get_doc_by_ids(self, ids: List[str]) -> List[Document]:
+        ids = tuple(ids)
         with Session(PGKBService.engine) as session:
             stmt = text("SELECT document, cmetadata FROM langchain_pg_embedding WHERE collection_id in :ids")
             results = [Document(page_content=row[0], metadata=row[1]) for row in


### PR DESCRIPTION
修复使用pg向量库类型时的bug，原来的代码在做sql查询时用的数据结构是list，需要转换为tuple类型。