### PR TITLE
增加对 `.htm` 扩展名的显式支持，以解决 `.htm` 格式网页可被上传但不被入库的问题

### DIFF
--- a/server/knowledge_base/utils.py
+++ b/server/knowledge_base/utils.py
@@ -85,7 +85,7 @@ def list_files_from_folder(kb_name: str):
     return result
 
 
-LOADER_DICT = {"UnstructuredHTMLLoader": ['.html'],
+LOADER_DICT = {"UnstructuredHTMLLoader": ['.html', '.htm'],
                "MHTMLLoader": ['.mhtml'],
                "UnstructuredMarkdownLoader": ['.md'],
                "JSONLoader": [".json"],


### PR DESCRIPTION
Streamlit 的文件浏览器在添加 `.html` 扩展名支持后，会自动、隐式地支持上传 `.htm` 扩展名：

![htm_implicitly_supported](https://github.com/chatchat-space/Langchain-Chatchat/assets/59825102/9470bfdb-c3fa-49f6-b5ee-1bd75d216e94)

而 `utils.py` 中并没有将 `.htm` 扩展名归入加载器，因此上传的所有 `.htm` 格式网页都不会被正确加入知识库。

`.htm` 和 `.html` 扩展名都是 HTML 文档，无本质区别，因此直接将 `.htm` 扩展名也列入 `UnstructuredHTMLLoader`。