### PR TITLE
修复bge编码模型的query_instruction字段不生效的问题

### DIFF
--- a/server/embeddings_api.py
+++ b/server/embeddings_api.py
@@ -22,6 +22,10 @@ def embed_texts(
             from server.utils import load_local_embeddings
 
             embeddings = load_local_embeddings(model=embed_model)
+
+            if to_query:
+                texts = [getattr(embeddings, 'query_instruction', '') + text for text in texts]
+
             return BaseResponse(data=embeddings.embed_documents(texts))
 
         if embed_model in list_online_embed_models():  # 使用在线API
@@ -53,6 +57,10 @@ async def aembed_texts(
             from server.utils import load_local_embeddings
 
             embeddings = load_local_embeddings(model=embed_model)
+
+            if to_query:
+                texts = [getattr(embeddings, 'query_instruction', '') + text for text in texts]
+
             return BaseResponse(data=await embeddings.aembed_documents(texts))
 
         if embed_model in list_online_embed_models(): # 使用在线API


### PR DESCRIPTION
针对bge系列编码模型，例如bge-large-zh-v1.5模型，我发现server/knowledge_base/kb_cache/base.py代码中设置的以下编码query_instruction其实并没有真正被用到，源码[link](https://github.com/chatchat-space/Langchain-Chatchat/blob/master/server/knowledge_base/kb_cache/base.py#L139)：
```
if 'zh' in model:
    # for chinese model
    query_instruction = "为这个句子生成表示以用于检索相关文章："
elif 'en' in model:
    # for english model
    query_instruction = "Represent this sentence for searching relevant passages:"
else:
    # maybe ReRanker or else, just use empty string instead
    query_instruction = ""
```

上面这些query_instruction字段要通过调用HuggingFaceBgeEmbeddings的embed_query函数才会被使用，调用embed_documents函数不会被使用。HuggingFaceBgeEmbeddings的实现细节请看下面的源码。
```
  def embed_documents(self, texts: List[str]) -> List[List[float]]:
      texts = [t.replace("\n", " ") for t in texts]
      embeddings = self.client.encode(texts, **self.encode_kwargs)
      return embeddings.tolist()

  def embed_query(self, text: str) -> List[float]:
      text = text.replace("\n", " ")
      embedding = self.client.encode(
          self.query_instruction + text, **self.encode_kwargs
      )
      return embedding.tolist()
```
https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/embeddings/huggingface.py#L247

但是，langchain-chatchat的embeddings_api.py源码中，就只用到了embed_documents函数，这意味着现在的query_instruction只是设置了，在query编码时，其实没有生效，没有真正投入使用。
这种做法就和BGE编码模型的官方推荐调用方式背离了，会影响query的召回效果，我猜测这个bug可能和issue: #1433 相关。

修复bug后的前后效果对比如下：
```
# 修复前，用“测试”两字作为关键词去找回文档
测试
<Response [200]>
[{'page_content': '这是一个测试', 'metadata': {'source': 'docs/测试值.txt', 'row': ''}, 'type': 'Document', 'id': None, 'score': 0.3293527662754059}, {'page_content': '这是一个测试AAAAA', 'metadata': {'source': 'docs/测试值AAAA.txt', 'row': ''}, 'type': 'Document', 'id': None, 'score': 0.6302040815353394}, {'page_content': '这是一个测试,milvus', 'metadata': {'source': 'docs/hello_milvus.txt', 'row': ''}, 'type': 'Document', 'id': None, 'score': 0.6536833643913269}]
```

```
# 修复后，同样用“测试”两字作为关键词去找回文档
测试
<Response [200]>
[{'page_content': '这是一个测试', 'metadata': {'source': 'docs/测试值.txt', 'row': ''}, 'type': 'Document', 'id': None, 'score': 0.7405834794044495}, {'page_content': '这是一个测试,milvus', 'metadata': {'source': 'docs/hello_milvus.txt', 'row': ''}, 'type': 'Document', 'id': None, 'score': 0.9074904322624207}, {'page_content': '这是一个测试AAAAA', 'metadata': {'source': 'docs/测试值AAAA.txt', 'row': ''}, 'type': 'Document', 'id': None, 'score': 0.9368950128555298}]
```

可以看到score相似度的差异是非常大的，希望官方尽快修复，谢谢～