### PR TITLE
修复使用Milvus数据库时上传知识库文件报错的问题

### DIFF
--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -39,6 +39,8 @@ def search_docs(
             data = [DocumentWithVSId(**x[0].dict(), score=x[1], id=x[0].metadata.get("id")) for x in docs]
         elif file_name or metadata:
             data = kb.list_docs(file_name=file_name, metadata=metadata)
+            for d in data:
+                del d.metadata['vector']
     return data
 
 

--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -40,7 +40,8 @@ def search_docs(
         elif file_name or metadata:
             data = kb.list_docs(file_name=file_name, metadata=metadata)
             for d in data:
-                del d.metadata['vector']
+                if "vector" in d.metadata:
+                    del d.metadata["vector"]
     return data
 
 


### PR DESCRIPTION
当使用Milvus数据库时，上传知识库文件报错。

![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/50164305/4e3b1b7d-3550-4d02-a3c8-1a2fd44f43c9)

前台报错信息如上所示，后台报错信息如下所示：
```
`INFO:     127.0.0.1:41796 - "POST /knowledge_base/search_docs HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 322, in jsonable_encoder
    data = dict(obj)
           ^^^^^^^^^
TypeError: 'numpy.float32' object is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 327, in jsonable_encoder
    data = vars(obj)
           ^^^^^^^^^
TypeError: vars() argument must have __dict__ attribute

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 419, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/applications.py", line 119, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/routing.py", line 762, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/routing.py", line 782, in app
    await route.handle(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/routing.py", line 315, in app
    content = await serialize_response(
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/routing.py", line 170, in serialize_response
    return jsonable_encoder(
           ^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 301, in jsonable_encoder
    jsonable_encoder(
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 235, in jsonable_encoder
    return jsonable_encoder(
           ^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 287, in jsonable_encoder
    encoded_value = jsonable_encoder(
                    ^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 287, in jsonable_encoder
    encoded_value = jsonable_encoder(
                    ^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 301, in jsonable_encoder
    jsonable_encoder(
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/fastapi/encoders.py", line 330, in jsonable_encoder
    raise ValueError(errors) from e
ValueError: [TypeError("'numpy.float32' object is not iterable"), TypeError('vars() argument must have __dict__ attribute')]
2024-03-03 23:50:32,003 - _client.py[line:1027] - INFO: HTTP Request: POST http://127.0.0.1:7861/knowledge_base/search_docs "HTTP/1.1 500 Internal Server Error"
2024-03-03 23:50:32.004 Uncaught app exception
Traceback (most recent call last):
  File "/opt/anaconda3/envs/Chat-v0.2.10/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 535, in _run_script
    exec(code, module.__dict__)
  File "/opt/Langchain-Chatchat/webui.py", line 64, in <module>
    pages[selected_page]["func"](api=api, is_lite=is_lite)
  File "/opt/Langchain-Chatchat/webui_pages/knowledge_base/knowledge_base.py", line 328, in knowledge_base_page
    data = [
           ^
  File "/opt/Langchain-Chatchat/webui_pages/knowledge_base/knowledge_base.py", line 329, in <listcomp>
    {"seq": i + 1, "id": x["id"], "page_content": x["page_content"], "source": x["metadata"].get("source"),
                         ~^^^^^^
TypeError: string indices must be integers, not 'str'`
```

错误的地方在server/knowage_base/kb_doc_api.py的search_docs函数中
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/50164305/3f1ba12c-41fd-46b8-ab9c-e8aa1b5c7028)
`DocumentWithVSId`对象的metadata中包含有向量化后的数据，导致报错：
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/50164305/310520d5-8ad7-485f-ad88-5d5e6989d9b5)

