### PR TITLE
修复当向chat接口传入的max_tokens为None时可能会导致模型输出不完整的问题

### DIFF
--- a/server/chat/agent_chat.py
+++ b/server/chat/agent_chat.py
@@ -3,7 +3,7 @@ import asyncio
 
 from fastapi import Body
 from sse_starlette.sse import EventSourceResponse
-from configs import LLM_MODELS, TEMPERATURE, HISTORY_LEN, Agent_MODEL
+from configs import LLM_MODELS, TEMPERATURE, HISTORY_LEN, MAX_TOKENS, Agent_MODEL
 
 from langchain.chains import LLMChain
 from langchain.memory import ConversationBufferWindowMemory
@@ -31,7 +31,7 @@ async def agent_chat(query: str = Body(..., description="用户输入", examples
                      stream: bool = Body(False, description="流式输出"),
                      model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                      temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=1.0),
-                     max_tokens: Optional[int] = Body(None, description="限制LLM生成Token数量，默认None代表模型最大值"),
+                     max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认MAX_TOKENS代表模型最大值"),
                      prompt_name: str = Body("default",
                                              description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
                      ):

--- a/server/chat/chat.py
+++ b/server/chat/chat.py
@@ -1,6 +1,6 @@
 from fastapi import Body
 from sse_starlette.sse import EventSourceResponse
-from configs import LLM_MODELS, TEMPERATURE
+from configs import LLM_MODELS, TEMPERATURE, MAX_TOKENS
 from server.utils import wrap_done, get_ChatOpenAI
 from langchain.chains import LLMChain
 from langchain.callbacks import AsyncIteratorCallbackHandler
@@ -30,7 +30,7 @@ async def chat(query: str = Body(..., description="用户输入", examples=["恼
                stream: bool = Body(False, description="流式输出"),
                model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=2.0),
-               max_tokens: Optional[int] = Body(None, description="限制LLM生成Token数量，默认None代表模型最大值"),
+               max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认None代表模型最大值"),
                # top_p: float = Body(TOP_P, description="LLM 核采样。勿与temperature同时设置", gt=0.0, lt=1.0),
                prompt_name: str = Body("default", description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
                ):

--- a/server/chat/chat.py
+++ b/server/chat/chat.py
@@ -30,7 +30,7 @@ async def chat(query: str = Body(..., description="用户输入", examples=["恼
                stream: bool = Body(False, description="流式输出"),
                model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=2.0),
-               max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认None代表模型最大值"),
+               max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认MAX_TOKENS代表模型最大值"),
                # top_p: float = Body(TOP_P, description="LLM 核采样。勿与temperature同时设置", gt=0.0, lt=1.0),
                prompt_name: str = Body("default", description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
                ):

--- a/server/chat/completion.py
+++ b/server/chat/completion.py
@@ -1,6 +1,6 @@
 from fastapi import Body
 from sse_starlette.sse import EventSourceResponse
-from configs import LLM_MODELS, TEMPERATURE
+from configs import LLM_MODELS, TEMPERATURE, MAX_TOKENS
 from server.utils import wrap_done, get_OpenAI
 from langchain.chains import LLMChain
 from langchain.callbacks import AsyncIteratorCallbackHandler
@@ -16,7 +16,7 @@ async def completion(query: str = Body(..., description="用户输入", examples
                      echo: bool = Body(False, description="除了输出之外，还回显输入"),
                      model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                      temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=1.0),
-                     max_tokens: Optional[int] = Body(1024, description="限制LLM生成Token数量，默认None代表模型最大值"),
+                     max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认MAX_TOKENS代表模型最大值"),
                      # top_p: float = Body(TOP_P, description="LLM 核采样。勿与temperature同时设置", gt=0.0, lt=1.0),
                      prompt_name: str = Body("default",
                                              description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),

--- a/server/chat/file_chat.py
+++ b/server/chat/file_chat.py
@@ -1,6 +1,6 @@
 from fastapi import Body, File, Form, UploadFile
 from sse_starlette.sse import EventSourceResponse
-from configs import (LLM_MODELS, VECTOR_SEARCH_TOP_K, SCORE_THRESHOLD, TEMPERATURE,
+from configs import (LLM_MODELS, VECTOR_SEARCH_TOP_K, SCORE_THRESHOLD, TEMPERATURE, MAX_TOKENS,
                      CHUNK_SIZE, OVERLAP_SIZE, ZH_TITLE_ENHANCE)
 from server.utils import (wrap_done, get_ChatOpenAI,
                         BaseResponse, get_prompt_template, get_temp_dir, run_in_thread_pool)
@@ -104,7 +104,7 @@ async def file_chat(query: str = Body(..., description="用户输入", examples=
                     stream: bool = Body(False, description="流式输出"),
                     model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                     temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=1.0),
-                    max_tokens: Optional[int] = Body(None, description="限制LLM生成Token数量，默认None代表模型最大值"),
+                    max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认MAX_TOKENS代表模型最大值"),
                     prompt_name: str = Body("default", description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
                 ):
     if knowledge_id not in memo_faiss_pool.keys():

--- a/server/chat/knowledge_base_chat.py
+++ b/server/chat/knowledge_base_chat.py
@@ -5,6 +5,7 @@ from configs import (LLM_MODELS,
                      VECTOR_SEARCH_TOP_K, 
                      SCORE_THRESHOLD, 
                      TEMPERATURE,
+                     MAX_TOKENS,
                      USE_RERANKER,
                      RERANKER_MODEL,
                      RERANKER_MAX_LENGTH,
@@ -45,8 +46,8 @@ async def knowledge_base_chat(query: str = Body(..., description="用户输入",
                               model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                               temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=1.0),
                               max_tokens: Optional[int] = Body(
-                                  None,
-                                  description="限制LLM生成Token数量，默认None代表模型最大值"
+                                  MAX_TOKENS,
+                                  description="限制LLM生成Token数量，默认MAX_TOKENS代表模型最大值"
                               ),
                               prompt_name: str = Body(
                                   "default",

--- a/server/chat/search_engine_chat.py
+++ b/server/chat/search_engine_chat.py
@@ -1,6 +1,6 @@
 from langchain.utilities.bing_search import BingSearchAPIWrapper
 from langchain.utilities.duckduckgo_search import DuckDuckGoSearchAPIWrapper
-from configs import (BING_SEARCH_URL, BING_SUBSCRIPTION_KEY, METAPHOR_API_KEY,
+from configs import (BING_SEARCH_URL, BING_SUBSCRIPTION_KEY, METAPHOR_API_KEY, MAX_TOKENS,
                      LLM_MODELS, SEARCH_ENGINE_TOP_K, TEMPERATURE, OVERLAP_SIZE)
 from langchain.chains import LLMChain
 from langchain.callbacks import AsyncIteratorCallbackHandler
@@ -127,8 +127,8 @@ async def search_engine_chat(query: str = Body(..., description="用户输入", 
                              stream: bool = Body(False, description="流式输出"),
                              model_name: str = Body(LLM_MODELS[0], description="LLM 模型名称。"),
                              temperature: float = Body(TEMPERATURE, description="LLM 采样温度", ge=0.0, le=1.0),
-                             max_tokens: Optional[int] = Body(None,
-                                                              description="限制LLM生成Token数量，默认None代表模型最大值"),
+                             max_tokens: Optional[int] = Body(MAX_TOKENS,
+                                                              description="限制LLM生成Token数量，默认MAX_TOKENS代表模型最大值"),
                              prompt_name: str = Body("default",
                                                      description="使用的prompt模板名称(在configs/prompt_config.py中配置)"),
                              split_result: bool = Body(False,


### PR DESCRIPTION
今天我在使用谷歌的开源模型gemma-7b进行推理时，会出现以下问题：
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/60642274/224b2f6f-50ac-4bf4-abf1-b7f7bbb7aae2)
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/60642274/95da8b3f-f68a-403d-a7da-cf9207eb8905)

当向chat接口传入的max_tokens为None或者0时，可以观察到模型输出不完整。
在尝试将max_tokens调整到更大值时，解决了这个问题：
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/60642274/2d00d490-0938-458b-baab-c20c360f03e2)
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/60642274/e480b8e9-6f08-4a58-b734-26e70f160df9)


**解决方法和建议 / Solution and Advice**
对项目中server/chat/下的文件作如下修改：
Line 3
```python
from configs import LLM_MODELS, TEMPERATURE, MAX_TOKENS
``` 
Line 33
```python
max_tokens: Optional[int] = Body(MAX_TOKENS, description="限制LLM生成Token数量，默认None代表模型最大值"),
``` 