### PR TITLE
windows下启动失败提示补充python-multipart包

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ numpy>=1.26.3
 pandas~=2.1.4
 pydantic<2
 httpx[brotli,http2,socks]>=0.25.2
-
+python-multipart==0.0.9
 # optional document loaders
 
 # rapidocr_paddle[gpu]>=1.3.0.post5


### PR DESCRIPTION
原因：windows下启动失败提示补充python-multipart包
改动：requirements添加python-multipart==0.0.9
版本：0.0.9  Requires: Python >=3.8