### PR TITLE
faiss加载时，输入索引方式与实际初始化索引不符合

### DIFF
--- a/server/knowledge_base/kb_cache/faiss_cache.py
+++ b/server/knowledge_base/kb_cache/faiss_cache.py
@@ -58,7 +58,7 @@ class _FaissPool(CachePool):
         # create an empty vector store
         embeddings = get_Embeddings(embed_model=embed_model)
         doc = Document(page_content="init", metadata={})
-        vector_store = FAISS.from_documents([doc], embeddings, normalize_L2=True,distance_strategy="METRIC_INNER_PRODUCT")
+        vector_store = FAISS.from_documents([doc], embeddings, normalize_L2=True)
         ids = list(vector_store.docstore._dict.keys())
         vector_store.delete(ids)
         return vector_store


### PR DESCRIPTION
全流程分析在issue #3115 
通过删除传入的距离度量方式减少误解