### PR TITLE
Add new splitter to process QA type file(now only support JSON) and add Toggle button in knowledge_base page

### DIFF
--- a/configs/kb_config.py.example
+++ b/configs/kb_config.py.example
@@ -120,6 +120,10 @@ text_splitter_dict = {
         "source": "huggingface",   # 选择tiktoken则使用openai的方法
         "tokenizer_name_or_path": "",
     },
+    "QATextSplitter": {
+        "source": "huggingface",   # 选择tiktoken则使用openai的方法
+        "tokenizer_name_or_path": "",
+    },
     "SpacyTextSplitter": {
         "source": "huggingface",
         "tokenizer_name_or_path": "gpt2",
@@ -141,6 +145,8 @@ text_splitter_dict = {
 
 # TEXT_SPLITTER 名称
 TEXT_SPLITTER_NAME = "ChineseRecursiveTextSplitter"
+# QA_SPLITTER 名称
+QA_SPLITTER_NAME = "QATextSplitter"
 
 # Embedding模型定制词语的词表文件
 EMBEDDING_KEYWORD_FILE = "embedding_keywords.txt"

--- a/server/knowledge_base/utils.py
+++ b/server/knowledge_base/utils.py
@@ -274,6 +274,7 @@ class KnowledgeFile:
             filename: str,
             knowledge_base_name: str,
             loader_kwargs: Dict = {},
+            text_splitter_name: str = TEXT_SPLITTER_NAME,
     ):
         '''
         对应知识库目录中的文件，必须是磁盘上存在的才能进行向量化等操作。
@@ -288,7 +289,7 @@ class KnowledgeFile:
         self.docs = None
         self.splited_docs = None
         self.document_loader_name = get_LoaderClass(self.ext)
-        self.text_splitter_name = TEXT_SPLITTER_NAME
+        self.text_splitter_name = text_splitter_name
 
     def file2docs(self, refresh: bool = False):
         if self.docs is None or refresh:

--- a/text_splitter/__init__.py
+++ b/text_splitter/__init__.py
@@ -2,3 +2,4 @@ from .chinese_text_splitter import ChineseTextSplitter
 from .ali_text_splitter import AliTextSplitter
 from .zh_title_enhance import zh_title_enhance
 from .chinese_recursive_text_splitter import ChineseRecursiveTextSplitter
+from .qa_text_splitter import QATextSplitter

--- a/text_splitter/qa_text_splitter.py
+++ b/text_splitter/qa_text_splitter.py
@@ -1,0 +1,25 @@
+from typing import List, Optional, Any
+from langchain.text_splitter import TextSplitter
+
+class QATextSplitter(TextSplitter):
+    """Splitting QA file. Temporary only support json file."""
+    def __init__(
+        self,
+        keep_separator: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Create a new TextSplitter."""
+        super().__init__(keep_separator=keep_separator, **kwargs)
+
+
+    def split_text(self, text: str) -> List[str]:
+        json_text = eval(text)
+
+        splits = []
+        for qa in json_text:
+            question = qa["问题"]
+            answer = qa["答案"]
+        
+            splits.append(f"问题：{question}\n答案：{answer}")
+
+        return splits

--- a/webui_pages/utils.py
+++ b/webui_pages/utils.py
@@ -606,6 +606,7 @@ class ApiRequest:
             zh_title_enhance=ZH_TITLE_ENHANCE,
             docs: Dict = {},
             not_refresh_vs_cache: bool = False,
+            is_QA:bool = False
     ):
         '''
         对应api.py/knowledge_base/upload_docs接口
@@ -631,6 +632,7 @@ class ApiRequest:
             "zh_title_enhance": zh_title_enhance,
             "docs": docs,
             "not_refresh_vs_cache": not_refresh_vs_cache,
+            "is_QA":is_QA
         }
 
         if isinstance(data["docs"], dict):


### PR DESCRIPTION
I wrote a new splitter to improve the processing of QA-type knowledge(Now only supports JSON, as shown in the example). I also added a Toggle button on the knowledge_base page to switch between the QA splitter and the normal splitter (ChineseRecursiveTextSplitter defined in kb_config.py).

I created a PR because I noticed that many people are encountering the same issue (#3164, #893, and others).

Here are the updated page and test results for the QA splitter:
<img width="1166" alt="image" src="https://github.com/chatchat-space/Langchain-Chatchat/assets/72693206/ac89d4fe-7ad5-4d9c-938f-5608b69c8bde">
<img width="750" alt="image" src="https://github.com/chatchat-space/Langchain-Chatchat/assets/72693206/ca068a85-ac0d-405f-961e-d7880f8c559c">
