### PR TITLE
fix markdown header split (#1825)

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -95,8 +95,6 @@ class KBService(ABC):
         """
         if docs:
             custom_docs = True
-            for doc in docs:
-                doc.metadata.setdefault("source", kb_file.filename)
         else:
             docs = kb_file.file2text()
             custom_docs = False
@@ -105,6 +103,7 @@ class KBService(ABC):
             # 将 metadata["source"] 改为相对路径
             for doc in docs:
                 try:
+                    doc.metadata.setdefault("source", kb_file.filename)
                     source = doc.metadata.get("source", "")
                     if os.path.isabs(source):
                         rel_path = Path(source).relative_to(self.doc_path)


### PR DESCRIPTION
使用 UnstructuredMarkdownLoader 加载 Markdown 文档，会丢失 `#` 标题符号，导致无法利用 MarkdownHeaderTextSplitter 来根据标题来拆分文档 ( #1825 )。

为了解决这个问题，这里改为使用 TextLoader 来加载 Markdown 文档，达到按标题拆分 Markdown 文档的效果，单元测试如下：

![server/knowledge_base/utils.py:408](https://github.com/chatchat-space/Langchain-Chatchat/assets/13381443/f677405b-d1de-493b-a4a9-63494c389161)

此外，MarkdownHeaderTextSplitter 拆分之后的 Document 对象的 metadata 中没有 source 属性，会导致删除知识库文档时报错，具体位置为 server/knowledge_base/kb_service/faiss_kb_service.py:92 中的 `v.metadata.get("source").lower()`，这里一并修复了。