### PR TITLE
Dev fix csv loader

### DIFF
--- a/document_loaders/FilteredCSVloader.py
+++ b/document_loaders/FilteredCSVloader.py
@@ -62,7 +62,7 @@ class FilteredCSVLoader(CSVLoader):
             content = []
             for col in self.columns_to_read:
                 if col in row:
-                    content.append(str(row[col]))
+                    content.append(f'{col}:{str(row[col])}')
                 else:
                     raise ValueError(f"Column '{self.columns_to_read[0]}' not found in CSV file.")
             content = '\n'.join(content)

--- a/document_loaders/FilteredCSVloader.py
+++ b/document_loaders/FilteredCSVloader.py
@@ -59,23 +59,26 @@ class FilteredCSVLoader(CSVLoader):
         docs = []
         csv_reader = csv.DictReader(csvfile, **self.csv_args)  # type: ignore
         for i, row in enumerate(csv_reader):
-            if self.columns_to_read[0] in row:
-                content = row[self.columns_to_read[0]]
-                # Extract the source if available
-                source = (
-                    row.get(self.source_column, None)
-                    if self.source_column is not None
-                    else self.file_path
-                )
-                metadata = {"source": source, "row": i}
+            content = []
+            for col in self.columns_to_read:
+                if col in row:
+                    content.append(str(row[col]))
+                else:
+                    raise ValueError(f"Column '{self.columns_to_read[0]}' not found in CSV file.")
+            content = '\n'.join(content)
+            # Extract the source if available
+            source = (
+                row.get(self.source_column, None)
+                if self.source_column is not None
+                else self.file_path
+            )
+            metadata = {"source": source, "row": i}
 
-                for col in self.metadata_columns:
-                    if col in row:
-                        metadata[col] = row[col]
+            for col in self.metadata_columns:
+                if col in row:
+                    metadata[col] = row[col]
 
-                doc = Document(page_content=content, metadata=metadata)
-                docs.append(doc)
-            else:
-                raise ValueError(f"Column '{self.columns_to_read[0]}' not found in CSV file.")
+            doc = Document(page_content=content, metadata=metadata)
+            docs.append(doc)
 
         return docs


### PR DESCRIPTION
In the original csv loader, although columns_to_read is of List[str] type, only the first value of columns_to_read is obtained in the specific logic. This has been improved so that the logic can read multiple fields normally.

原来的csv加载器中，虽然columns_to_read是List[str]类型，但是具体逻辑中只获取了columns_to_read的第一个值，这里进行了完善，使得逻辑能够正常读取多个字段