### PR TITLE
修复使用pgvector时get_doc_by_ids方法报错的bug及知识库文件删除后向量仍然存在的bug

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -222,6 +222,20 @@ class KBService(ABC):
                 pass
         return docs
 
+    def get_relative_source_path(self,filepath: str):
+      '''
+      将文件路径转化为相对路径，保证查询时一致
+      '''
+      relative_path = filepath
+      if os.path.isabs(relative_path):
+        try:
+          relative_path = Path(filepath).relative_to(self.doc_path)
+        except Exception as e:
+          print(f"cannot convert absolute path ({source}) to relative path. error is : {e}")
+
+      relative_path = str(relative_path.as_posix().strip("/"))
+      return relative_path
+
     @abstractmethod
     def do_create_kb(self):
         """

--- a/server/knowledge_base/kb_service/es_kb_service.py
+++ b/server/knowledge_base/kb_service/es_kb_service.py
@@ -184,7 +184,7 @@ class ESKBService(KBService):
             query = {
                 "query": {
                     "term": {
-                        "metadata.source.keyword": kb_file.filepath
+                        "metadata.source.keyword": self.get_relative_source_path(kb_file.filepath)
                     }
                 }
             }

--- a/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/server/knowledge_base/kb_service/pg_kb_service.py
@@ -28,9 +28,9 @@ class PGKBService(KBService):
 
     def get_doc_by_ids(self, ids: List[str]) -> List[Document]:
         with Session(PGKBService.engine) as session:
-            stmt = text("SELECT document, cmetadata FROM langchain_pg_embedding WHERE collection_id in :ids")
+            stmt = text("SELECT document, cmetadata FROM langchain_pg_embedding WHERE custom_id = ANY(:ids)")
             results = [Document(page_content=row[0], metadata=row[1]) for row in
-                       session.execute(stmt, {'ids': ids}).fetchall()]
+                      session.execute(stmt, {'ids': ids}).fetchall()]
             return results
     def del_doc_by_ids(self, ids: List[str]) -> bool:
         return super().del_doc_by_ids(ids)

--- a/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/server/knowledge_base/kb_service/pg_kb_service.py
@@ -71,11 +71,10 @@ class PGKBService(KBService):
 
     def do_delete_doc(self, kb_file: KnowledgeFile, **kwargs):
         with Session(PGKBService.engine) as session:
-            filepath = kb_file.filepath.replace('\\', '\\\\')
             session.execute(
                 text(
                     ''' DELETE FROM langchain_pg_embedding WHERE cmetadata::jsonb @> '{"source": "filepath"}'::jsonb;'''.replace(
-                        "filepath", filepath)))
+                        "filepath", self.get_relative_source_path(kb_file.filepath))))
             session.commit()
 
     def do_clear_vs(self):


### PR DESCRIPTION
- 1. fix:https://github.com/chatchat-space/Langchain-Chatchat/issues/3073

 使用faiss时一切正常切换到pg后知识库管理点击文件后报错
```
 File "F:\Coding\ai\Langchain-Chatchat\webui_pages\knowledge_base\knowledge_base.py", line 329, in <listcomp>
    {"seq": i + 1, "id": x["id"], "page_content": x["page_content"], "source": x["metadata"].get("source"),
                         ~^^^^^^
TypeError: string indices must be integers, not 'str'
```
实际是数据库查询出错无法返回结果：
```
2024-03-18 22:11:46 2024-03-18 14:11:46.474 UTC [112] ERROR:  syntax error at or near "ARRAY" at character 79
2024-03-18 22:11:46 2024-03-18 14:11:46.474 UTC [112] STATEMENT:  SELECT document, cmetadata FROM langchain_pg_embedding WHERE collection_id in ARRAY['7e3a331b-e52f-11ee-8b8f-f46d3fa52a67']
```

另外，where字句的字段collection_id是错误的无法匹配到，应该是custom_id

- 2. fix: https://github.com/chatchat-space/Langchain-Chatchat/issues/3403