### PR TITLE
实现了Langchain Chatchat对Ollama的支持

### DIFF
--- a/configs/model_config.py.example
+++ b/configs/model_config.py.example
@@ -124,6 +124,11 @@ ONLINE_LLM_MODEL = {
     "gemini-api": {
         "api_key": "",
         "provider": "GeminiWorker",
+    },
+    # Ollama 文档参考 https://ollama.com/
+    "ollama": {
+        "model_name": "", #Ollama要加载的模型，支持的模型列表请查阅https://ollama.com/library，如qwen:7b
+        "api_base_url": "http://{host}:{port}", #Ollama发布地址，如http://192.168.1.11:11434
     }
 
 }
@@ -311,4 +316,5 @@ SUPPORT_AGENT_MODEL = [
     "chatglm3-6b",
     "internlm2-chat-20b",
     "Orion-14B-Chat-Plugin",
+    "ollama",
 ]

--- a/server/chat/completion.py
+++ b/server/chat/completion.py
@@ -1,7 +1,7 @@
 from fastapi import Body
 from sse_starlette.sse import EventSourceResponse
 from configs import LLM_MODELS, TEMPERATURE
-from server.utils import wrap_done, get_OpenAI
+from server.utils import wrap_done, get_OpenAI,get_Ollama
 from langchain.chains import LLMChain
 from langchain.callbacks import AsyncIteratorCallbackHandler
 from typing import AsyncIterable, Optional
@@ -33,13 +33,24 @@ async def completion(query: str = Body(..., description="用户输入", examples
         if isinstance(max_tokens, int) and max_tokens <= 0:
             max_tokens = None
 
-        model = get_OpenAI(
-            model_name=model_name,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            callbacks=[callback],
-            echo=echo
-        )
+        if model_name =="ollama":
+            model = get_Ollama(
+                model_name=model_name,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                callbacks=[callback],
+                echo=echo
+            )
+        else:
+            model = get_OpenAI(
+                model_name=model_name,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                callbacks=[callback],
+                echo=echo
+            )
+
+        
 
         prompt_template = get_prompt_template("completion", prompt_name)
         prompt = PromptTemplate.from_template(prompt_template)

--- a/server/chat/file_chat.py
+++ b/server/chat/file_chat.py
@@ -2,7 +2,7 @@ from fastapi import Body, File, Form, UploadFile
 from sse_starlette.sse import EventSourceResponse
 from configs import (LLM_MODELS, VECTOR_SEARCH_TOP_K, SCORE_THRESHOLD, TEMPERATURE,
                      CHUNK_SIZE, OVERLAP_SIZE, ZH_TITLE_ENHANCE)
-from server.utils import (wrap_done, get_ChatOpenAI,
+from server.utils import (wrap_done, get_BaseChatModel,
                         BaseResponse, get_prompt_template, get_temp_dir, run_in_thread_pool)
 from server.knowledge_base.kb_cache.faiss_cache import memo_faiss_pool
 from langchain.chains import LLMChain
@@ -118,7 +118,7 @@ async def file_chat(query: str = Body(..., description="用户输入", examples=
         if isinstance(max_tokens, int) and max_tokens <= 0:
             max_tokens = None
 
-        model = get_ChatOpenAI(
+        model = get_BaseChatModel(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -135,8 +135,14 @@ async def file_chat(query: str = Body(..., description="用户输入", examples=
             prompt_template = get_prompt_template("knowledge_base_chat", "empty")
         else:
             prompt_template = get_prompt_template("knowledge_base_chat", prompt_name)
-        input_msg = History(role="user", content=prompt_template).to_msg_template(False)
-        chat_prompt = ChatPromptTemplate.from_messages(
+        if model_name =="ollama":
+            prompt_template=prompt_template.replace("{ ", "").replace(" }", "")
+            input_msg = History(role="user", content=prompt_template).to_msg_tuple()
+            chat_prompt = ChatPromptTemplate.from_messages(
+            [i.to_msg_tuple() for i in history] + [input_msg])
+        else:
+           input_msg = History(role="user", content=prompt_template).to_msg_template(False)
+           chat_prompt = ChatPromptTemplate.from_messages(
             [i.to_msg_template() for i in history] + [input_msg])
 
         chain = LLMChain(prompt=chat_prompt, llm=model)

--- a/server/chat/search_engine_chat.py
+++ b/server/chat/search_engine_chat.py
@@ -11,7 +11,7 @@ from langchain.docstore.document import Document
 from fastapi import Body
 from fastapi.concurrency import run_in_threadpool
 from sse_starlette import EventSourceResponse
-from server.utils import wrap_done, get_ChatOpenAI
+from server.utils import wrap_done, get_BaseChatModel
 from server.utils import BaseResponse, get_prompt_template
 from server.chat.utils import History
 from typing import AsyncIterable
@@ -154,7 +154,7 @@ async def search_engine_chat(query: str = Body(..., description="用户输入", 
         if isinstance(max_tokens, int) and max_tokens <= 0:
             max_tokens = None
 
-        model = get_ChatOpenAI(
+        model = get_BaseChatModel(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -165,8 +165,14 @@ async def search_engine_chat(query: str = Body(..., description="用户输入", 
         context = "\n".join([doc.page_content for doc in docs])
 
         prompt_template = get_prompt_template("search_engine_chat", prompt_name)
-        input_msg = History(role="user", content=prompt_template).to_msg_template(False)
-        chat_prompt = ChatPromptTemplate.from_messages(
+        if model_name =="ollama":
+            prompt_template=prompt_template.replace("{ ", "").replace(" }", "")
+            input_msg = History(role="user", content=prompt_template).to_msg_tuple()
+            chat_prompt = ChatPromptTemplate.from_messages(
+            [i.to_msg_tuple() for i in history] + [input_msg])
+        else:
+            input_msg = History(role="user", content=prompt_template).to_msg_template(False)
+            chat_prompt = ChatPromptTemplate.from_messages(
             [i.to_msg_template() for i in history] + [input_msg])
 
         chain = LLMChain(prompt=chat_prompt, llm=model)


### PR DESCRIPTION
1、采用Langchain的Ollama库，新建get_BaseChatModel方法，按照名称返回ChatOllama或ChatOpenAI实例；
2、在model_config.py.example中添加了ollama相关配置,用于设置ollama模型名称和ollama部署发布地址；
3、在chat.py,knowledge_base_chat.py,file_chat.py,search_engine_chat.py,agent_chat.py中将原有的get_BaseChatOpenAI改为get_BaseChatModel，按照模型名称返回ChatOpenAI或ChatOllama实例； 
4、ollama的Prompt不支持类似"{{ input }}"这样的变量格式，只能是单括号且没有空格的定义方式，类似"{input}"，因而在部分对话模块添加了字符串替换处理:prompt_template=prompt_template.replace("{ ", "").replace(" }", "")；
5、langchain的ollama没有model_name属性，因此在agent_chat.py添加了判断是否有该属性的代码；
6、对话历史转换部分，由于ollama不支持通过to_msg_template转换后的格式，但是支持tuple格式，因此根据模型名称判断，如果是ollama模型，改为调用to_msg_tuple方法。