### PR TITLE
知识库 API 支持列举文件详情

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -144,7 +144,7 @@ def mount_knowledge_routes(app: FastAPI):
     from server.knowledge_base.kb_doc_api import (list_files, upload_docs, delete_docs,
                                                 update_docs, download_doc, recreate_vector_store,
                                                 search_docs, DocumentWithVSId, update_info,
-                                                update_docs_by_id,)
+                                                update_docs_by_id, list_files_detail)
 
     app.post("/chat/knowledge_base_chat",
              tags=["Chat"],
@@ -182,6 +182,12 @@ def mount_knowledge_routes(app: FastAPI):
             response_model=ListResponse,
             summary="获取知识库内的文件列表"
             )(list_files)
+    
+    app.get("/knowledge_base/list_files_detail",
+            tags=["Knowledge Base Management"],
+            response_model=BaseResponse,
+            summary="获取知识库内的文件列表详情"
+            )(list_files_detail)
 
     app.post("/knowledge_base/search_docs",
              tags=["Knowledge Base Management"],

--- a/server/knowledge_base/kb_doc_api.py
+++ b/server/knowledge_base/kb_doc_api.py
@@ -12,7 +12,7 @@ from fastapi.responses import FileResponse
 from sse_starlette import EventSourceResponse
 from pydantic import Json
 import json
-from server.knowledge_base.kb_service.base import KBServiceFactory
+from server.knowledge_base.kb_service.base import KBServiceFactory, get_kb_file_details
 from server.db.repository.knowledge_file_repository import get_file_detail
 from langchain.docstore.document import Document
 from server.knowledge_base.model.kb_document_model import DocumentWithVSId
@@ -74,6 +74,17 @@ def list_files(
     else:
         all_doc_names = kb.list_files()
         return ListResponse(data=all_doc_names)
+
+
+def list_files_detail(
+        knowledge_base_name: str
+) -> BaseResponse:
+    if not validate_kb_name(knowledge_base_name):
+        return ListResponse(code=403, msg="Don't attack me", data=[])
+
+    knowledge_base_name = urllib.parse.unquote(knowledge_base_name)
+    result = get_kb_file_details(knowledge_base_name)
+    return BaseResponse(data=result)
 
 
 def _save_files_in_thread(files: List[UploadFile],


### PR DESCRIPTION
原本的 API 没有暴露此功能，Streamlit WebUI 直接通过内部函数调用完成了文件详情的查询。

本 Pr 将该功能暴露为 API，方便外界调用，API 示例如下：

**Request:**

```
curl -X 'GET' \
  'http://127.0.0.1:7861/knowledge_base/list_files_detail?knowledge_base_name=trip' \
  -H 'accept: application/json'
```

**Respounce:**

```
{
  "code": 200,
  "msg": "success",
  "data": [
    {
      "kb_name": "trip",
      "file_name": "A级旅游景区_2024-01-01.csv",
      "file_ext": ".csv",
      "file_version": 1,
      "document_loader": "CSVLoader",
      "docs_count": 7,
      "text_splitter": "ChineseRecursiveTextSplitter",
      "create_time": "2024-04-02T04:21:51",
      "in_folder": true,
      "in_db": true,
      "file_mtime": 1712031188.8099997,
      "file_size": 865,
      "custom_docs": false,
      "No": 1
    },
    {
      "kb_name": "trip",
      "file_name": "A级旅游景区信息_2022-12-29.csv",
      "file_ext": ".csv",
      "file_version": 1,
      "document_loader": "CSVLoader",
      "docs_count": 47,
      "text_splitter": "ChineseRecursiveTextSplitter",
      "create_time": "2024-04-02T04:21:52",
      "in_folder": true,
      "in_db": true,
      "file_mtime": 1712031188.8201814,
      "file_size": 5472,
      "custom_docs": false,
      "No": 2
    }
  ]
}
```