### PR TITLE
对向量库的操作提供统一的接口

### DIFF
--- a/chatchat-server/chatchat/server/file_rag/retrievers/vectorstore.py
+++ b/chatchat-server/chatchat/server/file_rag/retrievers/vectorstore.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from chatchat.server.file_rag.retrievers.base import BaseRetrieverService
 from langchain.vectorstores import VectorStore
 from langchain_core.retrievers import BaseRetriever
@@ -18,7 +20,7 @@ class VectorstoreRetrieverService(BaseRetrieverService):
     def from_vectorstore(
             vectorstore: VectorStore,
             top_k: int,
-            score_threshold: int or float,
+            score_threshold: int | float,
     ):
         retriever = vectorstore.as_retriever(
             search_type="similarity_score_threshold",

--- a/chatchat-server/chatchat/server/file_rag/schema.py
+++ b/chatchat-server/chatchat/server/file_rag/schema.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import List
+
+from langchain.pydantic_v1 import BaseModel, Field
+from langchain.schema.document import Document
+
+
+class NodeMetadata(BaseModel):
+    file_source: str = Field("", title="文件路径")
+    file_name: str = Field("", title="文件名称")
+    node_type: str = Field("")
+    title: str = Field("", title="标题")
+    summanry: str = Field("", title="总结/摘要")
+
+    _doc_hash: str = ""
+    _doc_id: str = ""
+    _doc_ref_id: str = Field("", title="源文档ID")
+    _parent_id: str = ""
+    _prev_id: str = ""
+    _next_id: str = ""
+
+    _fields_to_embed: List[str] = ["title"]
+    _fields_to_content: List[str] = ["title"]
+
+    class Config:
+        extra = "allow"
+
+
+class TextNode(Document):
+    metadata: NodeMetadata = Field(default_factory=NodeMetadata)
+    type: str = "TextNode"
+
+    @property
+    def doc_id(self) -> str:
+        return self.metadata._doc_id
+    
+    @property
+    def doc_ref_id(self) -> str:
+        return self.metadata._doc_ref_id
+    
+    @doc_ref_id.setter
+    def doc_ref_id(self, id: str):
+        self.metadata._doc_ref_id = id
+
+    @property
+    def parent_id(self) -> str:
+        return self.metadata._parent_id
+
+    @parent_id.setter
+    def parent_id(self, id):
+        self.metadata._parent_id = id
+
+    @property
+    def prev_id(self) -> str:
+        return self.metadata._prev_id
+    
+    @prev_id.setter
+    def prev_id(self, id: str):
+        self.metadata._prev_id = id
+
+    @property
+    def next_id(self) -> str:
+        return self.metadata._next_id
+
+    @next_id.setter
+    def next_id(self, id: str):
+        self.metadata._next_id = id
+    
+    @property
+    def fields_to_embed(self) -> List[str]:
+        return self.metadata._fields_to_embed
+    
+    @fields_to_embed.setter
+    def fields_to_embed(self, val: List[str]):
+        self.metadata._fields_to_embed = val.copy()
+    
+    @property
+    def fields_to_content(self) -> List[str]:
+        return self.metadata._fields_to_content
+    
+    @fields_to_content.setter
+    def fields_to_content(self, val: List[str]):
+        self.metadata._fields_to_content = val.copy()
+
+    def get_content(self) -> str:
+        meta = {v.get("title", k) for k,v in self.metadata.schema()["properties"]}
+        return (
+            "\n".join([f"{k}: {v}" for k,v in meta.items() if k in self.fields_to_content]),
+            "\n",
+            self.page_content or "",
+        )
+
+    def get_embed_content(self) -> str:
+        meta = {v.get("title", k) for k,v in self.metadata.schema()["properties"]}
+        return (
+            "\n".join([f"{k}: {v}" for k,v in meta.items() if k in self.fields_to_embed]),
+            "\n",
+            self.page_content or "",
+        )

--- a/chatchat-server/chatchat/server/file_rag/vector_stores/myfaiss.py
+++ b/chatchat-server/chatchat/server/file_rag/vector_stores/myfaiss.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import enum
+import os
+from threading import RLock, Event
+from typing import Dict, List, Tuple, Optional, Callable, Any, Literal
+
+from langchain.schema.document import Document
+from langchain.vectorstores.faiss import FAISS as _FAISS
+from langchain_community.docstore.base import Docstore
+from langchain_community.vectorstores.utils import DistanceStrategy
+from langchain_core.embeddings import Embeddings
+from memoization import cached, CachingAlgorithmFlag
+
+from chatchat.configs import CACHED_VS_NUM, CACHED_MEMO_VS_NUM, logger, log_verbose
+
+
+__all = ["FaissStore", "LocalFaissCache", "MemoFaissCache"]
+
+
+class FaissStore(_FAISS):
+    '''
+    make FAISS to load lazy and thread safe
+    you should not instant it directly, use factory instead
+    '''
+    def __init__(
+        self,
+        embedding_function: Embeddings = None,
+        index: enum.Any = None,
+        docstore: Docstore = None,
+        index_to_docstore_id: Dict[int, str] = {},
+        relevance_score_fn: Callable[[float], float] | None = None,
+        normalize_L2: bool = False,
+        distance_strategy: DistanceStrategy = DistanceStrategy.EUCLIDEAN_DISTANCE,
+        folder_path: str = None,
+        index_name: str = "index",
+    ):
+        # let us instance a FAISS object without loading index
+        super().__init__(
+            embedding_function=embedding_function,
+            index=index,
+            docstore=docstore,
+            index_to_docstore_id=index_to_docstore_id,
+            relevance_score_fn=relevance_score_fn,
+            normalize_L2=normalize_L2,
+            distance_strategy=distance_strategy,
+        )
+        self.folder_path = folder_path
+        self.index_name = index_name
+        self.write_lock = RLock()
+        self.ready_to_search = Event()
+        self.last_mtime = None
+
+    def __add(self, texts: enum.Iterable[str], embeddings: enum.Iterable[List[float]], metadatas: enum.Iterable[Dict] | None = None, ids: List[str] | None = None) -> List[str]:
+        '''
+        all add_* methods go through here
+        '''
+        with self.write_lock:
+            self.ready_to_search.clear()
+            ret = super().__add(texts, embeddings, metadatas, ids)
+            if self.folder_path:
+                self.save_local()
+            self.ready_to_search.set()
+            return ret
+
+    def delete(self, ids: List[str] | None = None, **kwargs: enum.Any) -> bool | None:
+        with self.write_lock:
+            self.ready_to_search.clear()
+            ret = super().delete(ids, **kwargs)
+            if self.folder_path:
+                self.save_local()
+            self.ready_to_search.set()
+            return ret
+
+    @classmethod
+    def _copy_from_faiss(cls, vs: _FAISS):
+        obj = cls(
+            embedding_function = vs.embedding_function,
+            index = vs.index,
+            docstore = vs.docstore,
+            index_to_docstore_id = vs.index_to_docstore_id,
+            relevance_score_fn = vs.override_relevance_score_fn,
+            normalize_L2 = vs._normalize_L2,
+            distance_strategy = vs.distance_strategy,
+        )
+        return obj
+
+    @classmethod
+    def from_texts(
+        cls,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: List[Dict] | None = None,
+        ids: List[str] | None = None,
+        index_name: str = "index",
+        **kwargs: Any,
+    ) -> FaissStore:
+        '''
+        all from_* methods go through here.
+        make it init vector store with empty documents.
+        '''
+        is_empty = False
+        if not texts:
+            is_empty = True
+            texts = ["hello world"]
+            ids = ["temp_to_del"]
+        vs = super().from_texts(texts, embedding, metadatas, ids, **kwargs)
+        if is_empty:
+            vs.delete(ids)
+        obj = cls._copy_from_faiss(vs)
+        obj.index_name = index_name
+        obj.ready_to_search.set()
+        return obj
+
+    @classmethod
+    def load_local(
+        cls,
+        folder_path: str = None,
+        embeddings: Embeddings = None,
+        index_name: str = "index",
+        allow_dangerous_deserialization: bool = False,
+        **kwargs,
+    ) -> FaissStore:
+        vs = super().load_local(
+            folder_path=folder_path,
+            embeddings=embeddings,
+            index_name=index_name,
+            allow_dangerous_deserialization=allow_dangerous_deserialization,
+            **kwargs,
+        )
+        obj = cls._copy_from_faiss(vs)
+        obj.folder_path = folder_path
+        obj.index_name = index_name
+        obj.ready_to_search.set()
+        return obj
+
+    def save_local(self, folder_path: str = None, index_name: str = None) -> None:
+        folder_path = folder_path or self.folder_path
+        index_name = index_name or self.index
+        self.folder_path = folder_path
+        self.index_name = index_name
+        with self.write_lock:
+            self.ready_to_search.clear()
+            ret = super().save_local(folder_path, index_name)
+            index_path = os.path.join(folder_path, f"{index_name}.faiss")
+            mtime = int(os.path.getmtime(index_path))
+            self.last_mtime = mtime
+            self.ready_to_search.set()
+            return ret
+
+    def similarity_search_with_score_by_vector(self, embedding: List[float], k: int = 4, filter: Callable[..., Any] | Dict[str, enum.Any] | None = None, fetch_k: int = 20, **kwargs: enum.Any) -> List[Tuple[Document | float]]:
+        '''
+        all similarity search methods go through here
+        '''
+        self.ready_to_search.wait()
+        return super().similarity_search_with_score_by_vector(embedding, k, filter, fetch_k, **kwargs)
+
+    def max_marginal_relevance_search_with_score_by_vector(self, embedding: List[float], *, k: int = 4, fetch_k: int = 20, lambda_mult: float = 0.5, filter: Callable[..., Any] | Dict[str, enum.Any] | None = None) -> List[Tuple[Document | float]]:
+        '''
+        all max marginal relevance search methods go through here
+        '''
+        self.ready_to_search.wait()
+        return super().max_marginal_relevance_search_with_score_by_vector(embedding, k=k, fetch_k=fetch_k, lambda_mult=lambda_mult, filter=filter)
+
+
+def _custom_local_faiss_key(
+    embedding: Embeddings,
+    folder_path: str,
+    index_name: str,
+    allow_dangerous_deserialization: bool,
+):
+    """
+    Make a cache key with Embeddings support
+    """
+    return (
+        embedding.model,
+        folder_path,
+        index_name,
+        allow_dangerous_deserialization,
+    )
+
+
+@cached(max_size=CACHED_VS_NUM, algorithm=CachingAlgorithmFlag.LFU, custom_key_maker=_custom_local_faiss_key)
+def _load_local_faiss(
+    embedding: Embeddings,
+    folder_path: str,
+    index_name: str,
+    allow_dangerous_deserialization: bool,
+) -> FaissStore:
+    return FaissStore.load_local(
+        folder_path=folder_path,
+        embeddings=embedding,
+        index_name=index_name,
+        allow_dangerous_deserialization=allow_dangerous_deserialization,
+    )
+
+
+def LocalFaissCache(
+    embedding: Embeddings,
+    folder_path: str,
+    index_name: str = "index",
+    allow_dangerous_deserialization: bool = False,
+) -> FaissStore:
+    '''
+    factory function to load local faiss index with cache
+    '''
+    index_path = os.path.join(folder_path, f"{index_name}.faiss")
+    mtime = int(os.path.getmtime(index_path))
+
+    def _remove_outdated(arguments, result, is_alive):
+        '''remove cache that behind disk mtime'''
+        if (arguments[0] == (embedding, folder_path, index_name, allow_dangerous_deserialization)
+            and result.last_mtime < mtime):
+            return True
+        return False
+
+    _load_local_faiss.cache_remove_if(_remove_outdated)
+    result = _load_local_faiss(embedding, folder_path, index_name, allow_dangerous_deserialization)
+    if log_verbose:
+        logger.info(f"cache info for {folder_path}/{index_name}:\n{_load_local_faiss.cache_info()}")
+    return result
+
+
+def _custom_memo_faiss_key(index_name: str, embedding: Embeddings):
+    """
+    Make a cache key with Embeddings support
+    """
+    return (index_name, embedding.model)
+
+
+@cached(max_size=CACHED_MEMO_VS_NUM, algorithm=CachingAlgorithmFlag.LFU, custom_key_maker=_custom_memo_faiss_key)
+def _load_memo_faiss(index_name, embedding):
+    return FaissStore.from_texts([], embedding=embedding, index_name=index_name)
+
+def MemoFaissCache(
+    index_name: str,
+    embedding: Embeddings,
+) -> FaissStore:
+    '''
+    factory function to load memory faiss index with cache, an index_name should be specified.
+    '''
+    result = _load_memo_faiss(index_name, embedding)
+    if log_verbose:
+        logger.info(f"cache info for {index_name}:\n{_load_memo_faiss.cache_info()}")
+    return result

--- a/chatchat-server/chatchat/server/file_rag/vector_stores/vector_store_index.py
+++ b/chatchat-server/chatchat/server/file_rag/vector_stores/vector_store_index.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import enum
+from typing import Dict, List, Tuple, Optional, Callable, Any, Literal
+
+from langchain.schema.document import Document
+from langchain.vectorstores.base import VectorStore, VectorStoreRetriever
+from langchain_core.embeddings import Embeddings
+from sqlalchemy import text as sql_text
+
+from chatchat.configs import logger, log_verbose
+from chatchat.server.knowledge_base.utils import get_loader, make_text_splitter
+from chatchat.server.utils import get_ChatOpenAI, get_Embeddings
+from chatchat.server.file_rag.schema import TextNode
+from chatchat.server.file_rag.vector_stores.myfaiss import LocalFaissCache, MemoFaissCache, FaissStore
+
+
+class VectorStoreIndex(VectorStore):
+    '''
+    wrappr of vector store with helper methods such as crud etc.
+    '''
+    SUPPORT_VS_TYPES = ["Chroma", "ElasticsearchStore", "FAISS", "Milvus",
+                        "PGVector", "Zilliz"]
+
+    def __init__(
+        self,
+        vector_store: VectorStore,
+    ) -> None:
+        self.vector_store = vector_store
+        if not self.vs_type:
+            raise RuntimeError(f"provided vector store {vector_store} is not supported."
+                               " only {self.SUPPORT_VS_TYPES} supported.")
+
+    # override abstract methods, redirect to self.vector_store's methods
+
+    def add_texts(self, texts: enum.Iterable[str], metadatas: List[Dict] | None = None, **kwargs: Any) -> List[str]:
+        return self.vector_store.add_texts(texts, metadatas, **kwargs)
+    
+    @property
+    def embeddings(self) -> Embeddings:
+        return self.vector_store.embeddings
+    
+    def delete(self, ids: List[str] | None = None, **kwargs: Any) -> bool | None:
+        return self.vector_store.delete(ids, **kwargs)
+    
+    def similarity_search(self, query: str, k: int = 4, **kwargs: Any) -> List[Document]:
+        return self.vector_store.similarity_search(query, k, **kwargs)
+    
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        return self.vector_store._select_relevance_score_fn()
+    
+    def similarity_search_with_score(self, *args: Any, **kwargs: Any) -> List[Tuple[Document | float]]:
+        return self.vector_store.similarity_search_with_score(*args, **kwargs)
+    
+    def similarity_search_by_vector(self, embedding: List[float], k: int = 4, **kwargs: Any) -> List[Document]:
+        return self.vector_store.similarity_search_by_vector(embedding, k, **kwargs)
+    
+    def max_marginal_relevance_search(self, query: str, k: int = 4, fetch_k: int = 20, lambda_mult: float = 0.5, **kwargs: Any) -> List[Document]:
+        return self.vector_store.max_marginal_relevance_search(query, k, fetch_k, lambda_mult, **kwargs)
+    
+    def max_marginal_relevance_search_by_vector(self, embedding: List[float], k: int = 4, fetch_k: int = 20, lambda_mult: float = 0.5, **kwargs: Any) -> List[Document]:
+        return self.vector_store.max_marginal_relevance_search_by_vector(embedding, k, fetch_k, lambda_mult, **kwargs)
+    
+    @classmethod
+    def from_texts(cls, texts: List[str], embedding: Embeddings, metadatas: List[Dict] | None = None, **kwargs: Any) -> VectorStoreIndex:
+        raise NotImplementedError(f"{cls} should not be instanted directly by from_* mehtods.")
+
+    # some helper methods
+
+    @property
+    def vs_type(self) -> str:
+        '''
+        check vectorstore type automatically by cls name
+        '''
+        for cls in self.vector_store.__class__.mro():
+            if cls.__name__ in self.SUPPORT_VS_TYPES:
+                return cls.__name__
+
+    def upsert(self, documents: List[Tuple[Document, str]]) -> None:
+        '''
+        update existed documents, do insert if not exist.
+        '''
+        for doc, id in documents:
+            try:
+                if id:
+                    self.delete([id])
+            except Exception as e:
+                logger.error(f"failed to delete documents with id: {id} in {self.vector_store}.", exc_info=True)
+            finally:
+                if id:
+                    ids = [id]
+                else:
+                    ids = None
+                self.add_documents([doc], ids=ids)
+
+    def get_by_ids(self, ids: List[str]) -> List[Document]:
+        result = []
+        vs_type = self.vs_type
+        vs = self.vector_store
+
+        if vs_type == "Chroma":
+            get_result = vs._collection.get(ids=ids)
+            if get_result['documents']:
+                _metadatas = get_result['metadatas'] if get_result['metadatas'] else [{}] * len(get_result['documents'])
+                for page_content, metadata in zip(get_result['documents'], _metadatas):
+                    result.append(Document(**{'page_content': page_content, 'metadata': metadata}))
+        elif vs_type == "ElasticsearchStore":
+            for doc_id in ids:
+                try:
+                    response = vs.client.get(index=self.index_name, id=doc_id)
+                    source = response["_source"]
+                    # Assuming your document has "text" and "metadata" fields
+                    text = source.get("context", "")
+                    metadata = source.get("metadata", {})
+                    result.append(Document(page_content=text, metadata=metadata))
+                except Exception as e:
+                    logger.error(f"Error retrieving document from Elasticsearch! {e}")
+        elif vs_type == "FAISS":
+            result = [vs.docstore._dict.get(id) for id in ids]
+        elif vs_type in ["Milvus", "Zilliz"]:
+            pk_field = vs._primary_field
+            text_field = vs._text_field
+            vector_field = vs._vector_field
+            data_list = vs.col.query(expr=f'{pk_field} in {[int(_id) for _id in ids]}', output_fields=["*"])
+            for data in data_list:
+                text = data.pop(text_field, "")
+                data.pop(vector_field, None)
+                result.append(Document(page_content=text, metadata=data))
+        elif vs_type == "PGVector":
+            from sqlalchemy.orm import Session
+            with Session(vs._bind) as session:
+                stmt = sql_text("SELECT document, cmetadata FROM langchain_pg_embedding WHERE custom_id = ANY(:ids)")
+                result = [Document(page_content=row[0], metadata=row[1]) for row in
+                        session.execute(stmt, {'ids': ids}).fetchall()]
+        else:
+            raise RuntimeError(f"unsupported vector store: {vs}")
+
+        return result
+
+
+if __name__ == "__main__":
+    from langchain_community.vectorstores.pgvector import PGVector
+
+    from chatchat.configs.kb_config import kbs_config
+    from chatchat.server.utils import get_Embeddings
+
+    # test memory faiss
+    vs = MemoFaissCache("temp", get_Embeddings())
+    vs.add_texts(["test text"])
+    print(vs.similarity_search("test"))
+
+    vs2 = MemoFaissCache("temp", get_Embeddings())
+    print(vs.similarity_search("test"))
+
+    # test local vector store
+    vs = PGVector(kbs_config["pg"]["connection_uri"], get_Embeddings(), collection_name="test")
+    index = VectorStoreIndex(vs)
+
+    # test sinilarity search
+    print(index.similarity_search("chatchat"))
+
+    # test add
+    ids = index.add_texts(["test text"])
+
+    # test get
+    print(index.get_by_ids(ids))
+
+    # test upsert
+    index.upsert([(Document(page_content="updated test text 2"), ids[0])])
+    print(index.get_by_ids(ids))


### PR DESCRIPTION
- 参考 llama-index 添加 VectorStoreIndex[VectorStore]，统一对向量库的操作。除了 add/delete， 添加 upsert/get_by_ids 操作。
- 利用 memoization 重写 FAISS 的缓存功能，只保留写入竞争，解除检索竞争。当磁盘文件更新时自动刷新缓存。
- 参考 llama-index 添加支持更多功能的 TextNode[Document]
- 后续：重写 kb_cache 和 kb_service 模块

补充：VectorStoreIndex 本身的许多逻辑是从 kb_service 中抽取出来的，是一个标准的 langchain.VectorStore，具有更广泛的应用面，可以嵌入到任意 langchain 工作流中。