### PR TITLE
fix: 以lite模式启动时仅加载了在线嵌入模型,未加载配置的默认嵌入模型,导致创建知识库时报错 'bge-large-zh-v1.5'…

### DIFF
--- a/webui_pages/knowledge_base/knowledge_base.py
+++ b/webui_pages/knowledge_base/knowledge_base.py
@@ -108,6 +108,8 @@ def knowledge_base_page(api: ApiRequest, is_lite: bool = None):
 
             if is_lite:
                 embed_models = list_online_embed_models()
+                if EMBEDDING_MODEL not in embed_models:
+                    embed_models.append(EMBEDDING_MODEL)
             else:
                 embed_models = list_embed_models() + list_online_embed_models()
 


### PR DESCRIPTION
fix: 以lite模式启动时仅加载了在线嵌入模型,未加载配置的默认嵌入模型,导致创建知识库时报错 'bge-large-zh-v1.5' is not in list.
修复方式: 如果lite模式启动, 配置的默认嵌入模型也添加到列表