### PR TITLE
修改停止脚本，修复删除知识库后WebUI相应信息残留问题

### DIFF
--- a/shutdown_all.sh
+++ b/shutdown_all.sh
@@ -1,2 +1,6 @@
 # mac设备上的grep命令可能不支持grep -P选项，请使用Homebrew安装;或使用ggrep命令
-ps -eo pid,user,cmd|grep -P 'server/api.py|webui.py|fastchat.serve|multiprocessing'|grep -v grep|awk '{print $1}'|xargs kill -9
+if [[ "$(uname)" == "Darwin" ]]; then
+    ps -eo pid,user,command|grep -P 'server/api.py|webui.py|fastchat.serve|multiprocessing'|grep -v grep|awk '{print $1}'|xargs kill -9
+else
+    ps -eo pid,user,cmd|grep -P 'server/api.py|webui.py|fastchat.serve|multiprocessing'|grep -v grep|awk '{print $1}'|xargs kill -9
+fi


### PR DESCRIPTION
1. 问题：shutdown_all.sh在MacOS上不识别"cmd"。解决：使用"command"代替。
2. 问题：删除知识库时对应数据文件夹未被删除，导致WebUI中残留"知识库名(@)"的选项。解决：结合文件夹写权限的更改，删除数据文件夹。