### PR TITLE
支持embeddings使用类似openai api的server

### DIFF
--- a/configs/model_config.py.example
+++ b/configs/model_config.py.example
@@ -8,6 +8,24 @@ MODEL_ROOT_PATH = ""
 # 选用的 Embedding 名称
 EMBEDDING_MODEL = "bge-large-zh-v1.5"
 
+# 是否embedding使用openai like的api接口
+EMBEDDING_MODEL_USE_OPENAI = True
+# 这里tiktoken设置为false，并设置tiktoken model name为本地的hungginface的路径，可以使用指定的模型的tokenizer来切分。
+# 如果想使用openai tiktoken，则设置tiktoken enable为True。
+
+# chunk_size 设置单词请求的最大batch
+# embedding_ctx_length 设置单个batch的token的最大长度，需要小于等于模型限制的最大值
+EMBEDDING_MODEL_OPENAI = {
+    "model_name": "bge-large-zh-v1.5",
+    "api_base_url": "http://host:port/v1",
+    "api_key": "123",
+    "openai_proxy": "",
+    "tiktoken_enabled": False,
+    "tiktoken_model_name": "bge-large-zh-v1.5",
+    "chunk_size": 20,
+    "embedding_ctx_length": 256,
+}
+
 # Embedding 模型运行设备。设为 "auto" 会自动检测(会有警告)，也可手动设定为 "cuda","mps","cpu","xpu" 其中之一。
 EMBEDDING_DEVICE = "auto"
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -321,6 +321,22 @@ def list_config_llm_models() -> Dict[str, Dict]:
         "worker": workers,
     }
 
+def get_absulute_model_path(model_name: str, path_str: str):
+    path = Path(path_str)
+    if path.is_dir():  # 任意绝对路径
+        return str(path)
+    root_path = Path(MODEL_ROOT_PATH)
+    if root_path.is_dir():
+        path = root_path / model_name
+        if path.is_dir():  # use key, {MODEL_ROOT_PATH}/chatglm-6b
+            return str(path)
+        path = root_path / path_str
+        if path.is_dir():  # use value, {MODEL_ROOT_PATH}/THUDM/chatglm-6b-new
+            return str(path)
+        path = root_path / path_str.split("/")[-1]
+        if path.is_dir():  # use value split by "/", {MODEL_ROOT_PATH}/chatglm-6b-new
+            return str(path)
+    return path_str  # THUDM/chatglm06b
 
 def get_model_path(model_name: str, type: str = None) -> Optional[str]:
     if type in MODEL_PATH:
@@ -331,22 +347,7 @@ def get_model_path(model_name: str, type: str = None) -> Optional[str]:
             paths.update(v)
 
     if path_str := paths.get(model_name):  # 以 "chatglm-6b": "THUDM/chatglm-6b-new" 为例，以下都是支持的路径
-        path = Path(path_str)
-        if path.is_dir():  # 任意绝对路径
-            return str(path)
-
-        root_path = Path(MODEL_ROOT_PATH)
-        if root_path.is_dir():
-            path = root_path / model_name
-            if path.is_dir():  # use key, {MODEL_ROOT_PATH}/chatglm-6b
-                return str(path)
-            path = root_path / path_str
-            if path.is_dir():  # use value, {MODEL_ROOT_PATH}/THUDM/chatglm-6b-new
-                return str(path)
-            path = root_path / path_str.split("/")[-1]
-            if path.is_dir():  # use value split by "/", {MODEL_ROOT_PATH}/chatglm-6b-new
-                return str(path)
-        return path_str  # THUDM/chatglm06b
+        return get_absulute_model_path(model_name, path_str)
 
 
 # 从server_config中获取服务信息


### PR DESCRIPTION
目前只有embedding模型为text-embedding-ada-002的时候才会使用OpenAIEmbeddings

现在通过增加EMBEDDING_MODEL_USE_OPENAI和EMBEDDING_MODEL_OPENAI配置，可以使任意模型都可以通过OpenAIEmbeddings来调用自定义的类openai api的server来实现embedding。