### PR TITLE
'修改SupportedVSType类为枚举类'

### DIFF
--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 from langchain.embeddings.base import Embeddings
 from langchain.docstore.document import Document
+from enum import Enum
 
 from server.db.repository.knowledge_base_repository import (
     add_kb_to_db, delete_kb_from_db, list_kbs_from_db, kb_exists,

--- a/server/knowledge_base/kb_service/base.py
+++ b/server/knowledge_base/kb_service/base.py
@@ -40,7 +40,7 @@ def normalize(embeddings: List[List[float]]) -> np.ndarray:
     return np.divide(embeddings, norm)
 
 
-class SupportedVSType:
+class SupportedVSType(Enum):
     FAISS = 'faiss'
     MILVUS = 'milvus'
     DEFAULT = 'default'


### PR DESCRIPTION
SupportedVSType类应该修改为枚举类
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/6251172/3f1bad0b-1794-4bf7-8480-9e5121b4d962)
因为在类似下图传参的地方，如果不是枚举类，无法传类似`SupportedVSType.FAISS` 这样的枚举成员给第二个值，也就意味着第二个值是无效的
![image](https://github.com/chatchat-space/Langchain-Chatchat/assets/6251172/0f3dcc7f-ff92-464d-8d1f-16d29819c484)
修改为枚举类型之后，不影响下面代码的正常运行，可以通过getattr 取到类似 `SupportedVSType.FAISS` 这样的枚举成员，可以通过  `SupportedVSType.FAISS == vector_store_type` 这样的判断

```
 if isinstance(vector_store_type, str):
            vector_store_type = getattr(SupportedVSType, vector_store_type.upper())
        if SupportedVSType.FAISS == vector_store_type:
```