### PR TITLE
fix: fix the problem when Milvus is used as knowledge base

### DIFF
--- a/libs/chatchat-server/chatchat/configs/_kb_config.py
+++ b/libs/chatchat-server/chatchat/configs/_kb_config.py
@@ -162,6 +162,7 @@ class ConfigKbFactory(core_config.ConfigFactory[ConfigKb]):
                 "index_params": {
                     "metric_type": "L2",
                     "index_type": "HNSW",
+                    "params": {"M": 8, "efConstruction": 64},
                 },  # 在此处增加index_params
             },
             "chromadb": {},

--- a/libs/chatchat-server/chatchat/server/knowledge_base/kb_service/milvus_kb_service.py
+++ b/libs/chatchat-server/chatchat/server/knowledge_base/kb_service/milvus_kb_service.py
@@ -6,6 +6,7 @@ from langchain.vectorstores.milvus import Milvus
 
 from chatchat.configs import kbs_config
 from chatchat.server.db.repository import list_file_num_docs_id_by_kb_name_and_file_name
+from chatchat.server.utils import get_Embeddings
 from chatchat.server.file_rag.utils import get_Retriever
 from chatchat.server.knowledge_base.kb_service.base import (
     KBService,
@@ -58,11 +59,12 @@ class MilvusKBService(KBService):
 
     def _load_milvus(self):
         self.milvus = Milvus(
-            embedding_function=(self.embed_model),
+            embedding_function=get_Embeddings(self.embed_model),
             collection_name=self.kb_name,
             connection_args=kbs_config.get("milvus"),
             index_params=kbs_config.get("milvus_kwargs")["index_params"],
             search_params=kbs_config.get("milvus_kwargs")["search_params"],
+            auto_id=True,
         )
 
     def do_init(self):


### PR DESCRIPTION
Fix issue #4316
Similar PR #3431 for Langchain-ChatChat v0.3.0
* when Milvus is used as knowledge base, error without setting auto_id
* error when passing string as Embedding to initialize Milvus
* incorrect example of milvus initialize params