### PR TITLE
统一搜索引擎与本地知识库返回格式，修改 WEBUI 渲染上下文方式

### DIFF
--- a/libs/chatchat-server/chatchat/server/agent/tools_factory/search_internet.py
+++ b/libs/chatchat-server/chatchat/server/agent/tools_factory/search_internet.py
@@ -10,7 +10,7 @@ from strsimpy.normalized_levenshtein import NormalizedLevenshtein
 from chatchat.server.pydantic_v1 import Field
 from chatchat.server.utils import get_tool_config
 
-from .tools_registry import BaseToolOutput, regist_tool
+from .tools_registry import BaseToolOutput, regist_tool, format_context
 
 
 def bing_search(text, config):
@@ -98,19 +98,11 @@ def search_engine(query: str, config: dict):
         text=query, config=config["search_engine_config"][config["search_engine_name"]]
     )
     docs = search_result2docs(results)
-    context = ""
-    docs = [
-        f"""出处 [{inum + 1}] [{doc.metadata["source"]}]({doc.metadata["source"]}) \n\n{doc.page_content}\n\n"""
-        for inum, doc in enumerate(docs)
-    ]
-
-    for doc in docs:
-        context += doc + "\n"
-    return context
+    return {"docs": docs, "search_engine": config["search_engine_name"]}
 
 
 @regist_tool(title="互联网搜索")
 def search_internet(query: str = Field(description="query for Internet search")):
     """Use this tool to use bing search engine to search the internet and get information."""
     tool_config = get_tool_config("search_internet")
-    return BaseToolOutput(search_engine(query=query, config=tool_config))
+    return BaseToolOutput(search_engine(query=query, config=tool_config), format=format_context)

--- a/libs/chatchat-server/chatchat/server/agent/tools_factory/text2sql.py
+++ b/libs/chatchat-server/chatchat/server/agent/tools_factory/text2sql.py
@@ -129,7 +129,7 @@ def query_database(query: str, config: dict):
     return context
 
 
-@regist_tool(title="Text2Sql")
+@regist_tool(title="数据库对话")
 def text2sql(
     query: str = Field(
         description="No need for SQL statements,just input the natural language that you want to chat with database"

--- a/libs/chatchat-server/chatchat/server/agent/tools_factory/tools_registry.py
+++ b/libs/chatchat-server/chatchat/server/agent/tools_factory/tools_registry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import re
 from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
@@ -5,9 +7,11 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 from langchain.agents import tool
 from langchain_core.tools import BaseTool
 
+from chatchat.server.knowledge_base.kb_doc_api import DocumentWithVSId
 from chatchat.server.pydantic_v1 import BaseModel, Extra
 
-__all__ = ["regist_tool", "BaseToolOutput"]
+
+__all__ = ["regist_tool", "BaseToolOutput", "format_context"]
 
 
 _TOOLS_REGISTRY = {}
@@ -130,7 +134,7 @@ class BaseToolOutput:
     def __init__(
         self,
         data: Any,
-        format: str = "",
+        format: str | Callable = None,
         data_alias: str = "",
         **extras: Any,
     ) -> None:
@@ -143,5 +147,25 @@ class BaseToolOutput:
     def __str__(self) -> str:
         if self.format == "json":
             return json.dumps(self.data, ensure_ascii=False, indent=2)
+        elif callable(self.format):
+            return self.format(self)
         else:
             return str(self.data)
+
+
+def format_context(self: BaseToolOutput) -> str:
+    context = ""
+    docs = self.data["docs"]
+    source_documents = []
+
+    for inum, doc in enumerate(docs):
+        doc = DocumentWithVSId.parse_obj(doc)
+        source_documents.append(doc.page_content)
+
+    if len(source_documents) == 0:
+        context = "没有找到相关文档,请更换关键词重试"
+    else:
+        for doc in source_documents:
+            context += doc + "\n\n"
+
+    return context

--- a/libs/chatchat-server/chatchat/webui_pages/dialogue/dialogue.py
+++ b/libs/chatchat-server/chatchat/webui_pages/dialogue/dialogue.py
@@ -130,7 +130,7 @@ def clear_conv(name: str = None):
 
 # @st.cache_data
 def list_tools(_api: ApiRequest):
-    return _api.list_tools()
+    return _api.list_tools() or []
 
 
 def dialogue_page(
@@ -419,26 +419,28 @@ def dialogue_page(
                 chat_box.update_msg(text.replace("\n", "\n\n"))
             elif d.status is None:  # not agent chat
                 if getattr(d, "is_ref", False):
-                    context = ""
-                    docs = d.tool_output.get("docs")
-                    source_documents = []
-                    for inum, doc in enumerate(docs):
-                        doc = DocumentWithVSId.parse_obj(doc)
-                        filename = doc.metadata.get("source")
-                        parameters = urlencode(
-                            {
-                                "knowledge_base_name": d.tool_output.get(
-                                    "knowledge_base"
-                                ),
-                                "file_name": filename,
-                            }
-                        )
-                        url = (
-                            f"{api.base_url}/knowledge_base/download_doc?" + parameters
-                        )
-                        ref = f"""出处 [{inum + 1}] [{filename}]({url}) \n\n{doc.page_content}\n\n"""
-                        source_documents.append(ref)
-                    context = "\n".join(source_documents)
+                    context = str(d.tool_output)
+                    if isinstance(d.tool_output, dict):
+                        docs = d.tool_output.get("docs")
+                        source_documents = []
+                        for inum, doc in enumerate(docs):
+                            doc = DocumentWithVSId.parse_obj(doc)
+                            filename = doc.metadata.get("source")
+                            parameters = urlencode(
+                                {
+                                    "knowledge_base_name": d.tool_output.get(
+                                        "knowledge_base"
+                                    ),
+                                    "file_name": filename,
+                                }
+                            )
+                            url = (
+                                f"{api.base_url}/knowledge_base/download_doc?" + parameters
+                            )
+                            ref = f"""出处 [{inum + 1}] [{filename}]({url}) \n\n{doc.page_content}\n\n"""
+                            source_documents.append(ref)
+                        context = "\n".join(source_documents)
+
                     chat_box.insert_msg(
                         Markdown(
                             context,


### PR DESCRIPTION
- 修复：
    - 统一搜索引擎与本地知识库返回格式，修改 WEBUI 渲染上下文方式（close #4337)

- 开发者
  - 修改 BaseToolOutput 字符串化的方式，用传参代替子类化
