### PR TITLE
fix:解决es数据库删除时只能删除50条数据的BUG

### DIFF
--- a/libs/chatchat-server/chatchat/server/knowledge_base/kb_service/es_kb_service.py
+++ b/libs/chatchat-server/chatchat/server/knowledge_base/kb_service/es_kb_service.py
@@ -105,8 +105,7 @@ class ESKBService(KBService):
             ESKBService.get_kb_path(knowledge_base_name), "vector_store"
         )
 
-    def do_create_kb(self):
-        ...
+    def do_create_kb(self): ...
 
     def vs_type(self) -> str:
         return SupportedVSType.ES
@@ -154,10 +153,12 @@ class ESKBService(KBService):
                             kb_file.filepath
                         )
                     }
-                }
+                },
+                "track_total_hits": True,
             }
-            # 注意设置size，默认返回10个。
-            search_results = self.es_client_python.search(body=query, size=50)
+            # 注意设置size，默认返回10个，es检索设置track_total_hits为True返回数据库中真实的size。
+            size = self.es_client_python.search(body=query)["hits"]["total"]["value"]
+            search_results = self.es_client_python.search(body=query, size=size)
             delete_list = [hit["_id"] for hit in search_results["hits"]["hits"]]
             if len(delete_list) == 0:
                 return None


### PR DESCRIPTION
解决es数据库删除时只能删除50条数据的BUG。
源代码只能删除es数据库中对应index下的默认50条数，修改为删除全部数据。