### PR TITLE
Fix/max_tokens

### DIFF
--- a/libs/chatchat-server/chatchat/configs/_model_config.py
+++ b/libs/chatchat-server/chatchat/configs/_model_config.py
@@ -71,6 +71,11 @@ class ConfigModelFactory(core_config.ConfigFactory[ConfigModel]):
             "Qwen-14B-Chat",
             "Qwen-7B-Chat",
             "qwen-turbo",
+            "glm4-chat",
+            "glm4-chat-1m",
+            "qwen2-instruct",
+            "gpt-4o",
+            "gpt-3.5-turbo",
         ]
 
         #   ### 如果您已经有了一个openai endpoint的能力的地址，可以在这里直接配置
@@ -118,17 +123,35 @@ class ConfigModelFactory(core_config.ConfigFactory[ConfigModel]):
             {
                 "platform_name": "xinference",
                 "platform_type": "xinference",
-                "api_base_url": "http://127.0.0.1:9997/v1",
+                "api_base_url": "http://129.226.91.63:9997/v1",
                 "api_key": "EMPT",
                 "api_concurrencies": 5,
                 "llm_models": [
-                    "chatglm3",
                     "glm4-chat",
-                    "qwen1.5-chat",
                     "qwen2-instruct",
                 ],
                 "embed_models": [
                     "bge-large-zh-v1.5",
+                ],
+                "image_models": [],
+                "reranking_models": [],
+                "speech2text_models": [],
+                "tts_models": [],
+            },
+            {
+                "platform_name": "openai",
+                "platform_type": "openai",
+                "api_base_url": "https://api.openai.com/v1",
+                "api_key": "sk-",
+                "api_concurrencies": 5,
+                "llm_models": [
+                    "gpt-4o",
+                    "gpt-3.5-turbo",
+                ],
+                "embed_models": [
+                    "text-embedding-3-small",
+                    "text-embedding-3-large",
+                    "ada v2",
                 ],
                 "image_models": [],
                 "reranking_models": [],
@@ -254,7 +277,7 @@ class ConfigModelFactory(core_config.ConfigFactory[ConfigModel]):
             "preprocess_model": {
                 self.DEFAULT_LLM_MODEL: {
                     "temperature": 0.05,
-                    "max_tokens": 4096,
+                    "max_tokens": self.MAX_TOKENS,
                     "history_len": 100,
                     "prompt_name": "default",
                     "callbacks": False,
@@ -263,7 +286,7 @@ class ConfigModelFactory(core_config.ConfigFactory[ConfigModel]):
             "llm_model": {
                 self.DEFAULT_LLM_MODEL: {
                     "temperature": 0.9,
-                    "max_tokens": 4096,
+                    "max_tokens": self.MAX_TOKENS,
                     "history_len": 10,
                     "prompt_name": "default",
                     "callbacks": True,
@@ -272,7 +295,7 @@ class ConfigModelFactory(core_config.ConfigFactory[ConfigModel]):
             "action_model": {
                 self.DEFAULT_LLM_MODEL: {
                     "temperature": 0.01,
-                    "max_tokens": 4096,
+                    "max_tokens": self.MAX_TOKENS,
                     "prompt_name": "ChatGLM3",
                     "callbacks": True,
                 },
@@ -280,7 +303,7 @@ class ConfigModelFactory(core_config.ConfigFactory[ConfigModel]):
             "postprocess_model": {
                 self.DEFAULT_LLM_MODEL: {
                     "temperature": 0.01,
-                    "max_tokens": 4096,
+                    "max_tokens": self.MAX_TOKENS,
                     "prompt_name": "default",
                     "callbacks": True,
                 }

--- a/libs/chatchat-server/chatchat/server/agent/agent_factory/agents_registry.py
+++ b/libs/chatchat-server/chatchat/server/agent/agent_factory/agents_registry.py
@@ -43,6 +43,7 @@ def agents_registry(
             prompt = ChatPromptTemplate.from_messages([SystemMessage(content=prompt)])
         else:
             prompt = hub.pull("hwchase17/structured-chat-agent")  # default prompt
+
         agent = create_structured_chat_agent(llm=llm, tools=tools, prompt=prompt)
 
         agent_executor = AgentExecutor(

--- a/libs/chatchat-server/chatchat/server/agent/agent_factory/agents_registry.py
+++ b/libs/chatchat-server/chatchat/server/agent/agent_factory/agents_registry.py
@@ -43,7 +43,6 @@ def agents_registry(
             prompt = ChatPromptTemplate.from_messages([SystemMessage(content=prompt)])
         else:
             prompt = hub.pull("hwchase17/structured-chat-agent")  # default prompt
-
         agent = create_structured_chat_agent(llm=llm, tools=tools, prompt=prompt)
 
         agent_executor = AgentExecutor(

--- a/libs/chatchat-server/chatchat/server/api_server/chat_routes.py
+++ b/libs/chatchat-server/chatchat/server/api_server/chat_routes.py
@@ -16,7 +16,9 @@ from chatchat.server.utils import (
     get_tool,
     get_tool_config,
 )
-
+from chatchat.configs import (
+    MAX_TOKENS,
+)
 from .openai_routes import openai_request
 
 chat_router = APIRouter(prefix="/chat", tags=["ChatChat 对话"])
@@ -56,6 +58,11 @@ async def chat_completions(
     """
     # import rich
     # rich.print(body)
+
+    # 当调用本接口且 body 中没有传入 "max_tokens" 参数时, 默认使用配置中定义的值
+    if body.max_tokens == None:
+        body.max_tokens = MAX_TOKENS
+
     client = get_OpenAIClient(model_name=body.model, is_async=True)
     extra = {**body.model_extra} or {}
     for key in list(extra):
@@ -160,6 +167,7 @@ async def chat_completions(
             stream=body.stream,
             chat_model_config=extra.get("chat_model_config", chat_model_config),
             tool_config=extra.get("tool_config", tool_config),
+            max_tokens=body.max_tokens,
         )
         return result
     else:  # LLM chat directly

--- a/libs/chatchat-server/chatchat/server/chat/chat.py
+++ b/libs/chatchat-server/chatchat/server/chat/chat.py
@@ -40,7 +40,7 @@ def create_models_from_config(configs, callbacks, stream, max_tokens):
     for model_type, model_configs in configs.items():
         for model_name, params in model_configs.items():
             callbacks = callbacks if params.get("callbacks", False) else None
-            # 判断是否传入 max_tokens 的值, 如果传入就按传入的赋值( api 调用且赋值), 如果没有传入则按照初始化配置赋值( ui 调用或 api 调用未赋值)
+            # 判断是否传入 max_tokens 的值, 如果传入就按传入的赋值(api 调用且赋值), 如果没有传入则按照初始化配置赋值(ui 调用或 api 调用未赋值)
             max_tokens_value = max_tokens if max_tokens is not None else params.get("max_tokens", 1000)
             model_instance = get_ChatOpenAI(
                 model_name=model_name,
@@ -96,7 +96,6 @@ def create_models_chains(
         llm.callbacks = callbacks
         chain = LLMChain(prompt=chat_prompt, llm=llm, memory=memory)
         full_chain = {"input": lambda x: x["input"]} | chain
-
     return full_chain
 
 
@@ -141,7 +140,7 @@ async def chat(
             callbacks.append(langfuse_handler)
 
         models, prompts = create_models_from_config(
-            callbacks=callbacks, configs=chat_model_config, stream=stream, max_tokens=max_tokens,
+            callbacks=callbacks, configs=chat_model_config, stream=stream, max_tokens=max_tokens
         )
         all_tools = get_tool().values()
         tools = [tool for tool in all_tools if tool.name in tool_config]

--- a/libs/chatchat-server/chatchat/server/chat/chat.py
+++ b/libs/chatchat-server/chatchat/server/chat/chat.py
@@ -33,17 +33,19 @@ from chatchat.server.utils import (
 )
 
 
-def create_models_from_config(configs, callbacks, stream):
+def create_models_from_config(configs, callbacks, stream, max_tokens):
     configs = configs or LLM_MODEL_CONFIG
     models = {}
     prompts = {}
     for model_type, model_configs in configs.items():
         for model_name, params in model_configs.items():
             callbacks = callbacks if params.get("callbacks", False) else None
+            # 判断是否传入 max_tokens 的值, 如果传入就按传入的赋值( api 调用且赋值), 如果没有传入则按照初始化配置赋值( ui 调用或 api 调用未赋值)
+            max_tokens_value = max_tokens if max_tokens is not None else params.get("max_tokens", 1000)
             model_instance = get_ChatOpenAI(
                 model_name=model_name,
                 temperature=params.get("temperature", 0.5),
-                max_tokens=params.get("max_tokens", 1000),
+                max_tokens=max_tokens_value,
                 callbacks=callbacks,
                 streaming=stream,
                 local_wrap=True,
@@ -94,6 +96,7 @@ def create_models_chains(
         llm.callbacks = callbacks
         chain = LLMChain(prompt=chat_prompt, llm=llm, memory=memory)
         full_chain = {"input": lambda x: x["input"]} | chain
+
     return full_chain
 
 
@@ -116,6 +119,7 @@ async def chat(
     stream: bool = Body(True, description="流式输出"),
     chat_model_config: dict = Body({}, description="LLM 模型配置", examples=[]),
     tool_config: dict = Body({}, description="工具配置", examples=[]),
+    max_tokens: int = Body(None, description="LLM最大token数配置", example=4096),
 ):
     """Agent 对话"""
 
@@ -137,7 +141,7 @@ async def chat(
             callbacks.append(langfuse_handler)
 
         models, prompts = create_models_from_config(
-            callbacks=callbacks, configs=chat_model_config, stream=stream
+            callbacks=callbacks, configs=chat_model_config, stream=stream, max_tokens=max_tokens,
         )
         all_tools = get_tool().values()
         tools = [tool for tool in all_tools if tool.name in tool_config]

--- a/libs/chatchat-server/chatchat/server/utils.py
+++ b/libs/chatchat-server/chatchat/server/utils.py
@@ -33,6 +33,7 @@ from chatchat.configs import (
     HTTPX_DEFAULT_TIMEOUT,
     MODEL_PLATFORMS,
     TEMPERATURE,
+    MAX_TOKENS,
     log_verbose,
 )
 from chatchat.server.pydantic_v2 import BaseModel, Field
@@ -142,7 +143,7 @@ def get_model_info(
 def get_ChatOpenAI(
     model_name: str = DEFAULT_LLM_MODEL,
     temperature: float = TEMPERATURE,
-    max_tokens: int = None,
+    max_tokens: int = MAX_TOKENS,
     streaming: bool = True,
     callbacks: List[Callable] = [],
     verbose: bool = True,
@@ -188,7 +189,7 @@ def get_ChatOpenAI(
 def get_OpenAI(
     model_name: str,
     temperature: float,
-    max_tokens: int = None,
+    max_tokens: int = MAX_TOKENS,
     streaming: bool = True,
     echo: bool = True,
     callbacks: List[Callable] = [],

--- a/libs/chatchat-server/chatchat/webui_pages/dialogue/dialogue.py
+++ b/libs/chatchat-server/chatchat/webui_pages/dialogue/dialogue.py
@@ -18,6 +18,7 @@ from chatchat.configs import (
     LLM_MODEL_CONFIG,
     MODEL_PLATFORMS,
     TEMPERATURE,
+    MAX_TOKENS,
 )
 from chatchat.server.callback_handler.agent_callback_handler import AgentStatus
 from chatchat.server.knowledge_base.model.kb_document_model import DocumentWithVSId
@@ -366,6 +367,7 @@ def dialogue_page(
             tools=tools or openai.NOT_GIVEN,
             tool_choice=tool_choice,
             extra_body=extra_body,
+            max_tokens=MAX_TOKENS,
         ):
             # from pprint import pprint
             # pprint(d)


### PR DESCRIPTION
测试建议：
1、UI 问答时，需要按照如下命令设置 "max_tokens" 的值，并重启 chatchat 服务（只修改命令不重启会导致配置不生效）；
chatchat-config model --max_tokens=4096；

2、API 调用时，如果 body 中不传入 "max_tokens" 的值，则取原先配置中 "max_tokens" 设定的值，如果 body 中传入 "max_tokens" 的值，则当前传入的值生效，但不会修改原先配置中 "max_tokens" 设定的值；

3、使用`DEFAULT_LLM_MODEL`去调用 agent 问答，否则会报错（其他问题）

4、【可选】`chatchat-config model --max_tokens=xx`命令执行后，配置会保存在`~/.chatchat/workspace/workspace_ConfigModelconfig.json`中，可自行查看，如果感觉 llm 的表现与自己预期不符，不妨先重启下 chatchat 服务，重新读取下这里的配置文件会再测试（我就踩了更改配置没重启服务的坑😭😭😭）；