### PR TITLE
ollama not support the 'completion' mode

### DIFF
--- a/libs/chatchat-server/chatchat/configs/model_providers.yaml
+++ b/libs/chatchat-server/chatchat/configs/model_providers.yaml
@@ -46,4 +46,4 @@ xinference:
 #      model_type: 'llm'
 #      model_credentials:
 #        base_url: 'http://172.21.192.1:11434'
-#        mode: 'completion'
+#        mode: 'chat'


### PR DESCRIPTION
根据ollama官网的描述，如下文档https://github.com/ollama/ollama/blob/main/docs/openai.md
只提供了/v1/chat/completions类型的Endpoints，
model_providers.core.model_runtime.model_providers.ollama.llm.llm.OllamaLargeLanguageModel文件的108行代码，如果走else，client.completions.create，模型会报404错误，所以这个mode应该是'chat'，而不是'completion'。