### PR TITLE
feat:支持通过 Body 传入的 LLM 配置创建 Agent

### DIFF
--- a/libs/chatchat-server/chatchat/server/agent/tools_factory/text2promql.py
+++ b/libs/chatchat-server/chatchat/server/agent/tools_factory/text2promql.py
@@ -10,10 +10,7 @@ from langchain_core.runnables import RunnablePassthrough
 
 from chatchat.server.pydantic_v1 import Field
 from chatchat.server.utils import get_tool_config, get_ChatOpenAI
-# from chatchat.server.api_server.chat_routes import global_model_name
-# from chatchat.configs import (
-#     MAX_TOKENS,
-# )
+from chatchat.server.api_server.chat_routes import get_global_model_config
 
 from .tools_registry import BaseToolOutput, regist_tool
 
@@ -56,12 +53,12 @@ def query_prometheus(query: str, config: dict) -> str:
     password = config["password"]
 
     llm = get_ChatOpenAI(
-        # model_name=global_model_name,
-        # temperature=0.1,
-        # streaming=True,
-        # local_wrap=True,
-        # verbose=True,
-        # max_tokens=MAX_TOKENS,
+        model_name=get_global_model_config("model"),
+        temperature=get_global_model_config("temperature"),
+        streaming=get_global_model_config("stream"),
+        local_wrap=True,
+        verbose=True,
+        max_tokens=get_global_model_config("max_tokens"),
     )
 
     prometheus_prompt = ChatPromptTemplate.from_template(PROMETHEUS_PROMPT_TEMPLATE)

--- a/libs/chatchat-server/chatchat/server/agent/tools_factory/text2sql.py
+++ b/libs/chatchat-server/chatchat/server/agent/tools_factory/text2sql.py
@@ -51,16 +51,18 @@ def query_database(query: str, config: dict):
     read_only = config["read_only"]
     db = SQLDatabase.from_uri(sqlalchemy_connect_str)
 
-    from chatchat.server.api_server.chat_routes import global_model_name
+    from chatchat.server.api_server.chat_routes import get_global_model_config
     from chatchat.server.utils import get_ChatOpenAI
 
     llm = get_ChatOpenAI(
-        model_name=global_model_name,
-        temperature=0.1,
-        streaming=True,
+        model_name=get_global_model_config("model"),
+        temperature=get_global_model_config("temperature"),
+        streaming=get_global_model_config("stream"),
         local_wrap=True,
         verbose=True,
+        max_tokens=get_global_model_config("max_tokens"),
     )
+
     table_names = config["table_names"]
     table_comments = config["table_comments"]
     result = None

--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -330,37 +330,48 @@ class ApiModelSettings(BaseFileSettings):
         ]
     """支持的Agent模型"""
 
-    LLM_MODEL_CONFIG: t.Dict[str, t.Dict] = {
+    LLM_MODEL_CONFIG: t.Dict[str, t.Dict] = {}
+    """
+    LLM模型配置，包括了不同模态初始化参数。
+    `model` 如果留空则自动使用 DEFAULT_LLM_MODEL
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.LLM_MODEL_CONFIG = self._llm_model_config()
+
+    def _llm_model_config(self):
+        return {
             # 意图识别不需要输出，模型后台知道就行
             "preprocess_model": {
                 "model": "",
-                "temperature": 0.05,
-                "max_tokens": 4096,
-                "history_len": 10,
+                "temperature": self.TEMPERATURE,
+                "max_tokens": self.MAX_TOKENS,
+                "history_len": self.HISTORY_LEN,
                 "prompt_name": "default",
                 "callbacks": False,
             },
             "llm_model": {
                 "model": "",
-                "temperature": 0.9,
-                "max_tokens": 4096,
-                "history_len": 10,
+                "temperature": self.TEMPERATURE,
+                "max_tokens": self.MAX_TOKENS,
+                "history_len": self.HISTORY_LEN,
                 "prompt_name": "default",
                 "callbacks": True,
             },
             "action_model": {
-                "model": "",
-                "temperature": 0.01,
-                "max_tokens": 4096,
-                "history_len": 10,
+                "model": self.Agent_MODEL,
+                "temperature": self.TEMPERATURE,
+                "max_tokens": self.MAX_TOKENS,
+                "history_len": self.HISTORY_LEN,
                 "prompt_name": "ChatGLM3",
                 "callbacks": True,
             },
             "postprocess_model": {
                 "model": "",
-                "temperature": 0.01,
-                "max_tokens": 4096,
-                "history_len": 10,
+                "temperature": self.TEMPERATURE,
+                "max_tokens": self.MAX_TOKENS,
+                "history_len": self.HISTORY_LEN,
                 "prompt_name": "default",
                 "callbacks": True,
             },
@@ -369,10 +380,6 @@ class ApiModelSettings(BaseFileSettings):
                 "size": "256*256",
             },
         }
-    """
-    LLM模型配置，包括了不同模态初始化参数。
-    `model` 如果留空则自动使用 DEFAULT_LLM_MODEL
-    """
 
     MODEL_PLATFORMS: t.List[PlatformConfig] = [
             PlatformConfig(**{
@@ -458,8 +465,8 @@ class ApiModelSettings(BaseFileSettings):
                 "api_key": "sk-proj-",
                 "api_concurrencies": 5,
                 "llm_models": [
-                    "gpt-4o",
                     "gpt-3.5-turbo",
+                    "gpt-4o",
                 ],
                 "embed_models": [
                     "text-embedding-3-small",


### PR DESCRIPTION
1. 支持通过 Body 传入的 LLM 配置创建 Agent, 而非 `LLM_MODEL_CONFIG` 或 `DEFAULT_LLM_MODEL` 默认设定好的 LLM , 现在用户可以通过 UI 和 API 的方式来选择 LLM 使用 Agent 功能啦！
2. 修复了部分场景下 `text2sql` 和 `text2promql` 内部无法正确拿到 Body 传入的 LLM 信息的问题；
3. 优化了 `Agent_MODEL` 和 `LLM_MODEL_CONFIG` 部分参数的取值来源, 使其变得更合理.