### PR TITLE
修复init时，调用shutil.copytree，当src与dst一样时shutil报错的问题

### DIFF
--- a/libs/chatchat-server/chatchat/cli.py
+++ b/libs/chatchat-server/chatchat/cli.py
@@ -47,9 +47,11 @@ def init(
     logger.info(f"开始初始化项目数据目录：{Settings.CHATCHAT_ROOT}")
     Settings.basic_settings.make_dirs()
     logger.info("创建所有数据目录：成功。")
-    shutil.copytree(bs.PACKAGE_ROOT / "data/knowledge_base/samples", Path(bs.KB_ROOT_PATH) / "samples", dirs_exist_ok=True)
+    if(bs.PACKAGE_ROOT / "data/knowledge_base/samples" != Path(bs.KB_ROOT_PATH) / "samples"):
+        shutil.copytree(bs.PACKAGE_ROOT / "data/knowledge_base/samples", Path(bs.KB_ROOT_PATH) / "samples", dirs_exist_ok=True)
     logger.info("复制 samples 知识库文件：成功。")
-    shutil.copytree(bs.PACKAGE_ROOT / "data/nltk_data", bs.NLTK_DATA_PATH, dirs_exist_ok=True)
+    if (bs.PACKAGE_ROOT / "data/nltk_data" != bs.NLTK_DATA_PATH):
+        shutil.copytree(bs.PACKAGE_ROOT / "data/nltk_data", bs.NLTK_DATA_PATH, dirs_exist_ok=True)
     logger.info("复制 nltl_data：成功。")
     create_tables()
     logger.info("初始化知识库数据库：成功。")


### PR DESCRIPTION
环境：MacOS，Python3.11
问题：python cli.py init，当复制 samples 知识库文件及复制 nltl_data时，如果src与dst一样，shutil.copytree会报错：

File "/Users/tonysong/anaconda3/envs/chatchat/lib/python3.11/shutil.py", line 527, in _copytree
    raise Error(errors)
shutil.Error: ……

解决方法：判断src与dst一样一样时不再执行shutil.copytree