### PR TITLE
添加配置项，以便使用云服务器或反向代理时生成正确的公网 API 地址（如知识库文档下载链接）

### DIFF
--- a/libs/chatchat-server/chatchat/cli.py
+++ b/libs/chatchat-server/chatchat/cli.py
@@ -46,15 +46,16 @@ def init(
     Settings.set_auto_reload(False)
     bs = Settings.basic_settings
     kb_names = [x.strip() for x in kb_names.split(",")]
-    logger.info(f"开始初始化项目数据目录：{Settings.CHATCHAT_ROOT}")
+    logger.success(f"开始初始化项目数据目录：{Settings.CHATCHAT_ROOT}")
     Settings.basic_settings.make_dirs()
-    logger.info("创建所有数据目录：成功。")
+    logger.success("创建所有数据目录：成功。")
     if(bs.PACKAGE_ROOT / "data/knowledge_base/samples" != Path(bs.KB_ROOT_PATH) / "samples"):
         shutil.copytree(bs.PACKAGE_ROOT / "data/knowledge_base/samples", Path(bs.KB_ROOT_PATH) / "samples", dirs_exist_ok=True)
-    logger.info("复制 samples 知识库文件：成功。")
+    logger.success("复制 samples 知识库文件：成功。")
     nltk.data.path.append(str(bs.PACKAGE_ROOT / "data/nltk_data"))
+    logger.success("设置 nltk_data 路径：成功。")
     create_tables()
-    logger.info("初始化知识库数据库：成功。")
+    logger.success("初始化知识库数据库：成功。")
 
     if xf_endpoint:
         Settings.model_settings.MODEL_PLATFORMS[0].api_base_url = xf_endpoint
@@ -66,17 +67,17 @@ def init(
     Settings.createl_all_templates()
     Settings.set_auto_reload(True)
 
-    logger.info("生成默认配置文件：成功。")
-    logger.warning("<red>请先检查 model_settings.yaml 里模型平台、LLM模型和Embed模型信息正确</red>")
+    logger.success("生成默认配置文件：成功。")
+    logger.success("请先检查确认 model_settings.yaml 里模型平台、LLM模型和Embed模型信息已经正确")
 
     if recreate_kb:
         folder2db(kb_names=kb_names,
                   mode="recreate_vs",
                   vs_type=Settings.kb_settings.DEFAULT_VS_TYPE,
                   embed_model=get_default_embedding())
-        logger.success("<green>所有初始化已完成，执行 chatchat start -a 启动服务。</green>")
+        logger.success("所有初始化已完成，执行 chatchat start -a 启动服务。")
     else:
-        logger.success("<green>执行 chatchat kb -r 初始化知识库，然后 chatchat start -a 启动服务。</green>")
+        logger.success("执行 chatchat kb -r 初始化知识库，然后 chatchat start -a 启动服务。")
 
 
 main.add_command(startup_main, "start")

--- a/libs/chatchat-server/chatchat/server/api_server/openai_routes.py
+++ b/libs/chatchat-server/chatchat/server/api_server/openai_routes.py
@@ -106,7 +106,7 @@ async def openai_request(
             yield {"data": json.dumps({"error": str(e)})}
 
     params = body.model_dump(exclude_unset=True)
-    if params.get("max_tokens") == 0L
+    if params.get("max_tokens") == 0:
         params["max_tokens"] = Settings.model_settings.MAX_TOKENS
 
     if hasattr(body, "stream") and body.stream:

--- a/libs/chatchat-server/chatchat/server/chat/kb_chat.py
+++ b/libs/chatchat-server/chatchat/server/chat/kb_chat.py
@@ -20,7 +20,7 @@ from chatchat.server.knowledge_base.kb_doc_api import search_docs, search_temp_d
 from chatchat.server.knowledge_base.utils import format_reference
 from chatchat.server.utils import (wrap_done, get_ChatOpenAI, get_default_llm,
                                    BaseResponse, get_prompt_template, build_logger,
-                                   check_embed_model
+                                   check_embed_model, api_address
                                 )
 
 
@@ -83,7 +83,7 @@ async def kb_chat(query: str = Body(..., description="用户输入", examples=["
                                                 score_threshold=score_threshold,
                                                 file_name="",
                                                 metadata={})
-                source_documents = format_reference(kb_name, docs, request.base_url)
+                source_documents = format_reference(kb_name, docs, api_address(is_public=True))
             elif mode == "temp_kb":
                 ok, msg = check_embed_model()
                 if not ok:
@@ -93,7 +93,7 @@ async def kb_chat(query: str = Body(..., description="用户输入", examples=["
                                                 query=query,
                                                 top_k=top_k,
                                                 score_threshold=score_threshold)
-                source_documents = format_reference(kb_name, docs, request.base_url)
+                source_documents = format_reference(kb_name, docs, api_address(is_public=True))
             elif mode == "search_engine":
                 result = await run_in_threadpool(search_engine, query, top_k, kb_name)
                 docs = [x.dict() for x in result.get("docs", [])]

--- a/libs/chatchat-server/chatchat/server/knowledge_base/utils.py
+++ b/libs/chatchat-server/chatchat/server/knowledge_base/utils.py
@@ -475,8 +475,9 @@ def format_reference(kb_name: str, docs: List[Dict], api_base_url: str="") -> Li
                 "file_name": filename,
             }
         )
+        api_base_url = api_base_url.strip(" /")
         url = (
-            f"{api_base_url}knowledge_base/download_doc?" + parameters
+            f"{api_base_url}/knowledge_base/download_doc?" + parameters
         )
         page_content = doc.get("page_content")
         ref = f"""出处 [{inum + 1}] [{filename}]({url}) \n\n{page_content}\n\n"""

--- a/libs/chatchat-server/chatchat/server/utils.py
+++ b/libs/chatchat-server/chatchat/server/utils.py
@@ -617,13 +617,22 @@ def MakeFastAPIOffline(
 #         return path_str  # THUDM/chatglm06b
 
 
-def api_address() -> str:
+def api_address(is_public: bool = False) -> str:
+    '''
+    允许用户在 basic_settings.API_SERVER 中配置 public_host, public_port
+    以便使用云服务器或反向代理时生成正确的公网 API 地址（如知识库文档下载链接）
+    '''
     from chatchat.settings import Settings
 
-    host = Settings.basic_settings.API_SERVER["host"]
-    if host == "0.0.0.0":
-        host = "127.0.0.1"
-    port = Settings.basic_settings.API_SERVER["port"]
+    server = Settings.basic_settings.API_SERVER
+    if is_public:
+        host = server.get("public_host", "127.0.0.1")
+        port = server.get("public_port", "7861")
+    else:
+        host = server.get("host", "127.0.0.1")
+        port = server.get("port", "7861")
+        if host == "0.0.0.0":
+            host = "127.0.0.1"
     return f"http://{host}:{port}"
 
 

--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -23,7 +23,8 @@ XF_MODELS_TYPES = {
 class BasicSettings(BaseFileSettings):
     """
     服务器基本配置信息
-    除 log_verbose/HTTPX_DEFAULT_TIMEOUT 修改后即时生效，其它配置项修改后都需要重启服务器才能生效
+    除 log_verbose/HTTPX_DEFAULT_TIMEOUT 修改后即时生效
+    其它配置项修改后都需要重启服务器才能生效，服务运行期间请勿修改
     """
 
     model_config = SettingsConfigDict(yaml_file=CHATCHAT_ROOT / "basic_settings.yaml")
@@ -33,9 +34,6 @@ class BasicSettings(BaseFileSettings):
 
     log_verbose: bool = False
     """是否开启日志详细信息"""
-
-    LOG_FORMAT: str = "%(asctime)s - %(filename)s[line:%(lineno)d] - %(levelname)s: %(message)s"
-    """日志格式"""
 
     HTTPX_DEFAULT_TIMEOUT: float = 300
     """httpx 请求默认超时时间（秒）。如果加载模型或对话较慢，出现超时错误，可以适当加大该值。"""
@@ -101,14 +99,14 @@ class BasicSettings(BaseFileSettings):
     OPEN_CROSS_DOMAIN: bool = False
     """API 是否开启跨域"""
 
-    DEFAULT_BIND_HOST: str = "127.0.0.1" if sys.platform != "win32" else "127.0.0.1"
+    DEFAULT_BIND_HOST: str = "0.0.0.0" if sys.platform != "win32" else "127.0.0.1"
     """
     各服务器默认绑定host。如改为"0.0.0.0"需要修改下方所有XX_SERVER的host
     Windows 下 WEBUI 自动弹出浏览器时，如果地址为 "0.0.0.0" 是无法访问的，需要手动修改地址栏
     """
 
-    API_SERVER: dict = {"host": DEFAULT_BIND_HOST, "port": 7861}
-    """API 服务器地址"""
+    API_SERVER: dict = {"host": DEFAULT_BIND_HOST, "port": 7861, "public_host": "127.0.0.1", "public_port": 7861}
+    """API 服务器地址。其中 public_host 用于生成云服务公网访问链接（如知识库文档链接）"""
 
     WEBUI_SERVER: dict = {"host": DEFAULT_BIND_HOST, "port": 8501}
     """WEBUI 服务器地址"""

--- a/libs/chatchat-server/chatchat/webui_pages/dialogue/dialogue.py
+++ b/libs/chatchat-server/chatchat/webui_pages/dialogue/dialogue.py
@@ -19,8 +19,8 @@ from streamlit_paste_button import paste_image_button
 from chatchat.settings import Settings
 from chatchat.server.callback_handler.agent_callback_handler import AgentStatus
 from chatchat.server.knowledge_base.model.kb_document_model import DocumentWithVSId
+from chatchat.server.knowledge_base.utils import format_reference
 from chatchat.server.utils import MsgType, get_config_models, get_config_platforms, get_default_llm
-from chatchat.webui_pages.dialogue.utils import process_files
 from chatchat.webui_pages.utils import *
 
 
@@ -501,23 +501,9 @@ def dialogue_page(
                             context = str(d.tool_output)
                             if isinstance(d.tool_output, dict):
                                 docs = d.tool_output.get("docs", [])
-                                source_documents = []
-                                for inum, doc in enumerate(docs):
-                                    doc = DocumentWithVSId.parse_obj(doc)
-                                    filename = doc.metadata.get("source")
-                                    parameters = urlencode(
-                                        {
-                                            "knowledge_base_name": d.tool_output.get(
-                                                "knowledge_base"
-                                            ),
-                                            "file_name": filename,
-                                        }
-                                    )
-                                    url = (
-                                        f"{api.base_url}knowledge_base/download_doc?" + parameters
-                                    )
-                                    ref = f"""出处 [{inum + 1}] [{filename}]({url}) \n\n{doc.page_content}\n\n"""
-                                    source_documents.append(ref)
+                                source_documents = format_reference(kb_name=d.tool_output.get("knowledge_base"),
+                                                                    docs=docs,
+                                                                    api_base_url=api_address(is_public=True))
                                 context = "\n".join(source_documents)
 
                             chat_box.insert_msg(

--- a/libs/chatchat-server/chatchat/webui_pages/kb_chat.py
+++ b/libs/chatchat-server/chatchat/webui_pages/kb_chat.py
@@ -10,7 +10,7 @@ from streamlit_extras.bottom_container import bottom
 
 from chatchat.settings import Settings
 from chatchat.server.knowledge_base.utils import LOADER_DICT
-from chatchat.server.utils import get_config_models, get_config_platforms, get_default_llm
+from chatchat.server.utils import get_config_models, get_config_platforms, get_default_llm, api_address
 from chatchat.webui_pages.dialogue.dialogue import (save_session, restore_session, rerun,
                                                     get_messages_history, upload_temp_docs,
                                                     add_conv, del_conv, clear_conv)
@@ -194,8 +194,9 @@ def kb_chat(api: ApiRequest):
             return_direct=return_direct,
         )
     
+        api_url = api_address(is_public=True)
         if dialogue_mode == "知识库问答":
-            client = openai.Client(base_url=f"{api_address()}/knowledge_base/local_kb/{selected_kb}", api_key="NONE")
+            client = openai.Client(base_url=f"{api_url}/knowledge_base/local_kb/{selected_kb}", api_key="NONE")
             chat_box.ai_say([
                 Markdown("...", in_expander=True, title="知识库匹配结果", state="running", expanded=return_direct),
                 f"正在查询知识库 `{selected_kb}` ...",
@@ -205,13 +206,13 @@ def kb_chat(api: ApiRequest):
                 st.error("请先上传文件再进行对话")
                 st.stop()
             knowledge_id=st.session_state.get("file_chat_id")
-            client = openai.Client(base_url=f"{api_address()}/knowledge_base/temp_kb/{knowledge_id}", api_key="NONE")
+            client = openai.Client(base_url=f"{api_url}/knowledge_base/temp_kb/{knowledge_id}", api_key="NONE")
             chat_box.ai_say([
                 Markdown("...", in_expander=True, title="知识库匹配结果", state="running", expanded=return_direct),
                 f"正在查询文件 `{st.session_state.get('file_chat_id')}` ...",
             ])
         else:
-            client = openai.Client(base_url=f"{api_address()}/knowledge_base/search_engine/{search_engine}", api_key="NONE")
+            client = openai.Client(base_url=f"{api_url}/knowledge_base/search_engine/{search_engine}", api_key="NONE")
             chat_box.ai_say([
                 Markdown("...", in_expander=True, title="知识库匹配结果", state="running", expanded=return_direct),
                 f"正在执行 `{search_engine}` 搜索...",


### PR DESCRIPTION
- 新功能：
    - 允许用户在 basic_settings.API_SERVER 中配置 public_host,public_port，以便使用云服务器或反向代理时生成正确的公网 API 地址（如知识库文档下载链接）（close #4566）
- 开发者：
    - 删除无用配置项：LOG_FORMAT