### PR TITLE
fix:如果模型输出不是str，会导致ret=OpenAIChatOutput报错

### DIFF
--- a/libs/chatchat-server/chatchat/server/chat/chat.py
+++ b/libs/chatchat-server/chatchat/server/chat/chat.py
@@ -213,11 +213,12 @@ async def chat(
                             data["message_type"] = message_type
                     except:
                         ...
-
+                text_value = data.get("text", "")
+                content = text_value if isinstance(text_value, str) else str(text_value)
                 ret = OpenAIChatOutput(
                     id=f"chat{uuid.uuid4()}",
                     object="chat.completion.chunk",
-                    content=data.get("text", ""),
+                    content=content,
                     role="assistant",
                     tool_calls=data["tool_calls"],
                     model=models["llm_model"].model_name,


### PR DESCRIPTION
如果模型输出不是str，会导致ret=OpenAIChatOutput这一行报错，在前面先转换成str就好了。