### PR TITLE
fix: milvus RPC error

### DIFF
--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -210,7 +210,11 @@ class KBSettings(BaseFileSettings):
                 },
                 "index_params": {
                     "metric_type": "L2",
-                    "index_type": "HNSW"
+                    "index_type": "HNSW",
+                    "params": {
+                        "efConstruction": 128,
+                        "M": 16,
+                        "efSearch": 128}
                 }
             },
             "chromadb": {}


### PR DESCRIPTION
## Description
This pull request addresses the RPC error encountered in Milvus.

example:
```
RPC error: [create_index], <MilvusException: (code=1100, message=efConstruction out of range: [1, 2147483647]: invalid parameter[expected=valid index params][actual=invalid index params])>, <Time:{'RPC start': '2024-08-05 03:48:45.651572', 'RPC error': '2024-08-05 03:48:45.653054'}>
```

## Related Issues
- Closes #3977
- Closes #2819
