### PR TITLE
feat: Improving Elasticsearch https connections

### DIFF
--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -202,7 +202,11 @@ class KBSettings(BaseFileSettings):
                 "port": "9200",
                 "index_name": "test_index",
                 "user": "",
-                "password": ""
+                "password": "",
+                "verify_certs": True,
+                "ca_certs": None,
+                "client_cert": None,
+                "client_key": None
             },
             "milvus_kwargs": {
                 "search_params": {


### PR DESCRIPTION
添加ES连接采用https方法的验证证书 证书地址等参数，同时提供默认参数，向后兼容，不影响未设置用户。

补充上一次PR，因为ES默认docker是自签证书，不设置参数仍旧无法直接连接