### PR TITLE
fix: pg_similarity_search error: Relevance scores must be between 0 and 1 #5023

### DIFF
--- a/libs/chatchat-server/chatchat/server/knowledge_base/kb_service/pg_kb_service.py
+++ b/libs/chatchat-server/chatchat/server/knowledge_base/kb_service/pg_kb_service.py
@@ -29,7 +29,7 @@ class PGKBService(KBService):
         self.pg_vector = PGVector(
             embedding_function=get_Embeddings(self.embed_model),
             collection_name=self.kb_name,
-            distance_strategy=DistanceStrategy.EUCLIDEAN,
+            distance_strategy=DistanceStrategy.COSINE,
             connection=PGKBService.engine,
             connection_string=Settings.kb_settings.kbs_config.get("pg").get("connection_uri"),
         )


### PR DESCRIPTION
when I use pg as vector database
I got this error when I request search_docs api
`site-packages/langchain_core/vectorstores.py:330: UserWarning: Relevance scores must be between 0 and 1`

And I also see this Issues #5023 

So I made this pr