### PR TITLE
Update Python version recommendations in README.md

### DIFF
--- a/docs/contributing/README_dev.md
+++ b/docs/contributing/README_dev.md
@@ -15,7 +15,7 @@ Langchain-Chatchat 自 0.3.0 版本起，为方便支持用户使用 pip 方式�
 
 ### 1.1 安装 Poetry
 
-> 在安装 Poetry 之前，如果您使用 Conda，请创建并激活一个新的 Conda 环境，例如使用 `conda create -n chatchat python=3.9` 创建一个新的 Conda 环境。
+> 在安装 Poetry 之前，如果您使用 Conda，请创建并激活一个新的 Conda 环境，例如使用 `conda create -n chatchat python=3.11` 创建一个新的 Conda 环境。
 
 安装 Poetry: [Poetry 安装文档](https://python-poetry.org/docs/#installing-with-pipx)
 


### PR DESCRIPTION
In Langchain-Chatchat/libs/chatchat-server/pyproject.toml, the rapidocr_onnxruntime dependency is specified as ~1.3.8, which requires onnxruntime version >=1.7.0. However, according to the [ONNX Runtime 1.20.0 release notes](https://github.com/microsoft/onnxruntime/releases/tag/v1.20.0), ONNX Runtime will no longer support Python 3.8 and 3.9 as of version 1.20.0, following NumPy's Python version support policy.
