### PR TITLE
解决使用模型glm4-9b-chat报错“An error occurred during streaming”

### DIFF
--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -318,8 +318,9 @@ class ApiModelSettings(BaseFileSettings):
     HISTORY_LEN: int = 3
     """默认历史对话轮数"""
 
-    MAX_TOKENS: t.Optional[int] = None # TODO: 似乎与 LLM_MODEL_CONFIG 重复了
-    """大模型最长支持的长度，如果不填写，则使用模型默认的最大长度，如果填写，则为用户设定的最大长度"""
+    MAX_TOKENS: t.Optional[int] = 4096 # TODO: 似乎与 LLM_MODEL_CONFIG 重复了
+    """ 大模型支持的最大长度。填写后，如果调用模型时请求体中设置了 `max_tokens`，则优先使用请求体中的 `max_tokens` 值；否则，将使用此默认值。"""
+
 
     TEMPERATURE: float = 0.7
     """LLM通用对话参数"""


### PR DESCRIPTION
在 `Langchain-Chatchat/libs/chatchat-server/chatchat/server/api_server/chat_routes.py` 中，`max_tokens` 的定义为：

```python
# 当调用本接口且请求体中没有传入 "max_tokens" 参数时，默认使用配置中定义的值
if body.max_tokens in [None, 0]:
    body.max_tokens = Settings.model_settings.MAX_TOKENS
然而，Settings 中对 MAX_TOKENS 的解释为：

python
复制
MAX_TOKENS: t.Optional[int] = None  # 大模型支持的最大长度，如果未设置，则使用模型的默认最大长度；如果设置了，则为用户指定的最大长度
这意味着，如果 max_tokens 未在请求体中提供，系统将使用配置中的 MAX_TOKENS 作为默认值，此处不应设None