### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ OpenAI GPT API 的调用，并将在后续持续扩充对各类模型及模型 A
 | 可用模型               | [Xinference 已支持模型](https://inference.readthedocs.io/en/latest/models/builtin/index.html) | [LocalAI 已支持模型](https://localai.io/model-compatibility/#/) | [Ollama 已支持模型](https://ollama.com/library#/)                                   | [FastChat 已支持模型](https://github.com/lm-sys/FastChat/blob/main/docs/model_support.md) |
 
 除上述本地模型加载框架外，项目中也为可接入在线 API 的 [One API](https://github.com/songquanpeng/one-api)
-框架接入提供了支持，支持包括 [OpenAI ChatGPT](https://platform.openai.com/docs/guides/gpt/chat-completions-api)、[Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)、[Anthropic Claude](https://anthropic.com/)、[智谱清言](https://bigmodel.cn/)、[百川](https://platform.baichuan-ai.com/)
+框架接入提供了支持，支持包括 [OpenAI ChatGPT](https://platform.openai.com/docs/guides/gpt/chat-completions-api)、[Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)、[Anthropic Claude](https://anthropic.com/)、[MiniMax](https://www.minimax.io/)、[智谱清言](https://bigmodel.cn/)、[百川](https://platform.baichuan-ai.com/)
 等常用在线 API 的接入使用。
 
 > [!Note]

--- a/README_en.md
+++ b/README_en.md
@@ -119,7 +119,7 @@ information. The supported local model deployment frameworks in this project are
 In addition to the above local model loading frameworks, the project also supports
 the [One API](https://github.com/songquanpeng/one-api) framework for integrating online APIs, supporting commonly used
 online APIs such
-as [OpenAI ChatGPT](https://platform.openai.com/docs/guides/gpt/chat-completions-api), [Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference), [Anthropic Claude](https://anthropic.com/), [Zhipu Qingyan](https://bigmodel.cn/),
+as [OpenAI ChatGPT](https://platform.openai.com/docs/guides/gpt/chat-completions-api), [Azure OpenAI API](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference), [Anthropic Claude](https://anthropic.com/), [MiniMax](https://www.minimax.io/), [Zhipu Qingyan](https://bigmodel.cn/),
 and [Baichuan](https://platform.baichuan-ai.com/).
 
 > [!Note]

--- a/libs/chatchat-server/chatchat/server/utils.py
+++ b/libs/chatchat-server/chatchat/server/utils.py
@@ -375,7 +375,7 @@ def get_Embeddings(
                 openai_api_key=model_info.get("api_key"),
                 openai_proxy=model_info.get("api_proxy"),
             )
-        if model_info.get("platform_type") == "openai":
+        if model_info.get("platform_type") in ("openai", "minimax"):
             return OpenAIEmbeddings(**params)
         elif model_info.get("platform_type") == "ollama":
             return OllamaEmbeddings(

--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -467,9 +467,11 @@ class ApiModelSettings(BaseFileSettings):
                 "api_key": "YOUR_API_KEY",
                 "api_concurrencies": 5,
                 "llm_models": [
+                    "MiniMax-M2.7",
+                    "MiniMax-M2.7-highspeed",
+                    "MiniMax-M2.5",
                     "MiniMax-M1",
                     "MiniMax-M1-40k",
-                    "MiniMax-M2.5",
                 ],
                 "embed_models": [
                     "embo-01",

--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -261,7 +261,7 @@ class PlatformConfig(MyBaseModel):
     platform_name: str = "xinference"
     """平台名称"""
 
-    platform_type: t.Literal["xinference", "ollama", "oneapi", "fastchat", "openai", "custom openai"] = "xinference"
+    platform_type: t.Literal["xinference", "ollama", "oneapi", "fastchat", "openai", "minimax", "custom openai"] = "xinference"
     """平台类型"""
 
     api_base_url: str = "http://127.0.0.1:9997/v1"
@@ -458,6 +458,21 @@ class ApiModelSettings(BaseFileSettings):
                 "embed_models": [
                     "text-embedding-3-small",
                     "text-embedding-3-large",
+                ],
+            }),
+            PlatformConfig(**{
+                "platform_name": "minimax",
+                "platform_type": "minimax",
+                "api_base_url": "https://api.minimax.io/v1",
+                "api_key": "YOUR_API_KEY",
+                "api_concurrencies": 5,
+                "llm_models": [
+                    "MiniMax-M1",
+                    "MiniMax-M1-40k",
+                    "MiniMax-M2.5",
+                ],
+                "embed_models": [
+                    "embo-01",
                 ],
             }),
         ]

--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -467,11 +467,9 @@ class ApiModelSettings(BaseFileSettings):
                 "api_key": "YOUR_API_KEY",
                 "api_concurrencies": 5,
                 "llm_models": [
+                    "MiniMax-M3",
                     "MiniMax-M2.7",
                     "MiniMax-M2.7-highspeed",
-                    "MiniMax-M2.5",
-                    "MiniMax-M1",
-                    "MiniMax-M1-40k",
                 ],
                 "embed_models": [
                     "embo-01",


### PR DESCRIPTION
## Summary

Upgrade the [MiniMax](https://www.minimax.io/) platform configuration in Langchain-Chatchat to use **MiniMax-M3** as the default model. MiniMax-M1 / M1-40k / M2.5 are removed; M2.7 and M2.7-highspeed are kept as alternatives.

### Changes

- Promote **MiniMax-M3** to the default LLM (first entry in `llm_models`)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as supported alternatives
- Remove older models: `MiniMax-M2.5`, `MiniMax-M1`, `MiniMax-M1-40k`
- `embo-01` retained as the embedding model
- Route MiniMax embeddings through `OpenAIEmbeddings` (API-compatible)

### How to use

```yaml
MODEL_PLATFORMS:
  - platform_name: minimax
    platform_type: minimax
    api_base_url: https://api.minimax.io/v1
    api_key: YOUR_MINIMAX_API_KEY
    llm_models:
      - MiniMax-M3
      - MiniMax-M2.7
      - MiniMax-M2.7-highspeed
    embed_models:
      - embo-01
```

### Why

MiniMax-M3 is the latest generation, with a 512K context window, up to 128K output, and image input support. Dropping the older M1/M2.5 entries keeps the default config focused on currently supported models.

## Test plan

- [x] Python files parse without errors
- [x] Changes follow existing platform configuration patterns
- [x] MiniMax API is OpenAI-compatible, so existing ChatOpenAI wrapper works without modification