### PR TITLE
Add MiniMax regional API endpoints

### DIFF
--- a/libs/chatchat-server/chatchat/settings.py
+++ b/libs/chatchat-server/chatchat/settings.py
@@ -261,11 +261,16 @@ class PlatformConfig(MyBaseModel):
     platform_name: str = "xinference"
     """平台名称"""
 
-    platform_type: t.Literal["xinference", "ollama", "oneapi", "fastchat", "openai", "custom openai"] = "xinference"
+    platform_type: t.Literal[
+        "xinference", "ollama", "oneapi", "fastchat", "openai", "minimax", "custom openai"
+    ] = "xinference"
     """平台类型"""
 
     api_base_url: str = "http://127.0.0.1:9997/v1"
     """openai api url"""
+
+    anthropic_api_base_url: str = ""
+    """anthropic-compatible api url"""
 
     api_key: str = "EMPTY"
     """api key if available"""
@@ -458,6 +463,30 @@ class ApiModelSettings(BaseFileSettings):
                 "embed_models": [
                     "text-embedding-3-small",
                     "text-embedding-3-large",
+                ],
+            }),
+            PlatformConfig(**{
+                "platform_name": "minimax-global",
+                "platform_type": "minimax",
+                "api_base_url": "https://api.minimax.io/v1",
+                "anthropic_api_base_url": "https://api.minimax.io/anthropic",
+                "api_key": "YOUR_API_KEY",
+                "api_concurrencies": 5,
+                "llm_models": [
+                    "MiniMax-M3",
+                    "MiniMax-M2.7",
+                ],
+            }),
+            PlatformConfig(**{
+                "platform_name": "minimax-cn",
+                "platform_type": "minimax",
+                "api_base_url": "https://api.minimaxi.com/v1",
+                "anthropic_api_base_url": "https://api.minimaxi.com/anthropic",
+                "api_key": "YOUR_API_KEY",
+                "api_concurrencies": 5,
+                "llm_models": [
+                    "MiniMax-M3",
+                    "MiniMax-M2.7",
                 ],
             }),
         ]

--- a/libs/chatchat-server/tests/unit_tests/test_model_platform_settings.py
+++ b/libs/chatchat-server/tests/unit_tests/test_model_platform_settings.py
@@ -1,0 +1,26 @@
+from chatchat.settings import ApiModelSettings
+
+
+def test_minimax_platform_endpoints():
+    platforms = {
+        platform.platform_name: platform
+        for platform in ApiModelSettings.model_fields["MODEL_PLATFORMS"].default
+    }
+
+    expected_endpoints = {
+        "minimax-global": (
+            "https://api.minimax.io/v1",
+            "https://api.minimax.io/anthropic",
+        ),
+        "minimax-cn": (
+            "https://api.minimaxi.com/v1",
+            "https://api.minimaxi.com/anthropic",
+        ),
+    }
+
+    for platform_name, endpoints in expected_endpoints.items():
+        platform = platforms[platform_name]
+        assert platform.platform_type == "minimax"
+        assert platform.api_base_url == endpoints[0]
+        assert platform.anthropic_api_base_url == endpoints[1]
+        assert platform.llm_models == ["MiniMax-M3", "MiniMax-M2.7"]


### PR DESCRIPTION
Reason: The executable MiniMax platform configuration lacks complete global and China endpoint coverage.

This adds separate global and China MiniMax presets, each carrying its OpenAI-compatible and Anthropic-compatible route, and lists MiniMax-M3 and MiniMax-M2.7 in both regions. A focused unit test verifies the executable defaults.

Checks:

- `PYTHONPATH=libs/chatchat-server uv run --no-project --python 3.11 --with 'pytest>=7.3,<8' --with 'nltk~=3.8.1' --with 'pydantic~=2.11.1' --with 'pydantic-settings>=2.3.4' --with 'memoization==0.4.0' --with 'ruamel-yaml==0.18.6' pytest -q --noconftest -o addopts='' libs/chatchat-server/tests/unit_tests/test_model_platform_settings.py`
- `uvx --from 'ruff==0.1.15' ruff check --isolated libs/chatchat-server/tests/unit_tests/test_model_platform_settings.py`
- `uvx --from 'ruff==0.1.15' ruff format --check libs/chatchat-server/tests/unit_tests/test_model_platform_settings.py`
- `python3 -m compileall -q libs/chatchat-server/chatchat/settings.py libs/chatchat-server/tests/unit_tests/test_model_platform_settings.py`
