### PR TITLE
Fix MCP schema loading and document Parallel search setup

### DIFF
--- a/docs/contributing/agent.md
+++ b/docs/contributing/agent.md
@@ -30,6 +30,54 @@ Tool Factory 中用于存储特殊的工具，目前，Chatchat已经自带了�
 + 维基百科搜索工具：使用维基百科进行搜索。
 + WolframAlpha工具：计算复杂的公式和执行高级数学运算。
 
+## 通过 MCP 使用 Parallel 联网搜索
+
+开发者可以通过现有的 `MultiServerMCPClient` 接入 [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)，无需 Parallel 账号或 API key。免费匿名访问有速率限制。服务提供 `web_search`（网页搜索）和 `web_fetch`（网页文本提取）。
+
+当前客户端支持 stdio 和传统 SSE；Parallel 的 `https://search.parallel.ai/mcp` 使用 Streamable HTTP，因此这里通过 [mcp-remote](https://github.com/punkpeye/mcp-remote) 桥接。请先在运行 Chatchat 的环境中安装 Node.js 20 或更新版本，并确认 `npx` 在 `PATH` 中。首次执行时，`npx` 会下载示例指定的桥接版本。
+
+以下是 Python 客户端示例，在已安装项目依赖的环境中保存为脚本后运行。这是开发者接口的连接字典，不是 WebUI 的连接器表单或配置文件格式：
+
+```python
+import asyncio
+
+from langchain_chatchat.agent_toolkits.mcp_kit.client import MultiServerMCPClient
+
+
+async def main():
+    connections = {
+        "parallel": {
+            "transport": "stdio",
+            "command": "npx",
+            "args": [
+                "-y",
+                "mcp-remote@0.8.3",
+                "https://search.parallel.ai/mcp",
+                "--transport",
+                "http-only",
+            ],
+        }
+    }
+    async with MultiServerMCPClient(connections) as client:
+        print([tool.name for tool in client.get_tools()])
+        search = await client.get_tool("parallel", "web_search")
+        if search is None:
+            raise RuntimeError("Parallel web_search tool was not discovered")
+        result = await search.ainvoke({
+            "objective": "Find official Python documentation",
+            "search_queries": ["Python official documentation"],
+        })
+        print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+工具只能在 `async with` 的连接生命周期内调用。搜索结果是 JSON 文本，包含 `results`、来源 URL 和摘录；`web_fetch` 的结果还包含每个 URL 的 `errors`，使用时应一起检查。
+
+需要接入 Agent 时，可将同样的 `connections` 传给 `PlatformToolsRunnable.create_agent_executor` 的 `mcp_connections` 参数；传入空字典可停用这些连接。示例不会修改默认搜索引擎或已有连接。启用到 Agent 后，模型可能自行决定调用工具，无需每次另行询问。搜索问题、查询词、请求的 URL 及随工具调用提供的上下文会发送给 Parallel，因此请勿在调用参数中放入不希望发送到外部服务的内容。
+
 ## 增加自己的工具
 
 我们支持使用 LangChain方式来增加自己的工具，您可以参考 `libs/chatchat-server/chatchat/server/agent/tools_registry`

--- a/libs/chatchat-server/langchain_chatchat/agent_toolkits/mcp_kit/tools.py
+++ b/libs/chatchat-server/langchain_chatchat/agent_toolkits/mcp_kit/tools.py
@@ -45,7 +45,9 @@ def schema_dict_to_model(schema: Dict[str, Any]) -> Any:
 
     model_fields = {}
     for field_name, details in fields.items():
-        field_type_str = details['type']
+        # Composed schemas (for example anyOf) need not declare a top-level type.
+        # Leave them to the server, like other types this converter does not model.
+        field_type_str = details.get('type')
         
         # Add field description if available
         field_description = details.get('description', '')

--- a/libs/chatchat-server/tests/unit_tests/test_mcp_tool_schemas.py
+++ b/libs/chatchat-server/tests/unit_tests/test_mcp_tool_schemas.py
@@ -1,12 +1,13 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from mcp.types import CallToolResult, TextContent, Tool
+from pydantic.v1 import ValidationError
+
 from langchain_chatchat.agent_toolkits.mcp_kit.tools import (
     convert_mcp_tool_to_langchain_tool,
     schema_dict_to_model,
 )
-from mcp.types import CallToolResult, TextContent, Tool
-from pydantic.v1 import ValidationError
 
 
 @pytest.mark.asyncio

--- a/libs/chatchat-server/tests/unit_tests/test_mcp_tool_schemas.py
+++ b/libs/chatchat-server/tests/unit_tests/test_mcp_tool_schemas.py
@@ -1,0 +1,64 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_chatchat.agent_toolkits.mcp_kit.tools import (
+    convert_mcp_tool_to_langchain_tool,
+    schema_dict_to_model,
+)
+from mcp.types import CallToolResult, TextContent, Tool
+from pydantic.v1 import ValidationError
+
+
+@pytest.mark.asyncio
+async def test_tool_with_nullable_schema_preserves_arguments():
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text='{"results": []}')]
+    )
+    tool = convert_mcp_tool_to_langchain_tool(
+        "remote",
+        session,
+        Tool(
+            name="search",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "queries": {"type": "array", "items": {"type": "string"}},
+                    "context": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                },
+                "required": ["queries"],
+            },
+        ),
+    )
+
+    for arguments in (
+        {"queries": ["Python docs"]},
+        {"queries": ["Python docs"], "context": None},
+        {"queries": ["Python docs"], "context": "official sources"},
+    ):
+        assert await tool.ainvoke(arguments) == '{"results": []}'
+        session.call_tool.assert_awaited_with("search", arguments)
+
+
+def test_untyped_required_field_is_still_required():
+    schema = schema_dict_to_model(
+        {
+            "properties": {"value": {"description": "Any JSON value"}},
+            "required": ["value"],
+        }
+    )
+    assert schema(value={"nested": [1, "two"]}).value == {"nested": [1, "two"]}
+    with pytest.raises(ValidationError):
+        schema()
+
+
+@pytest.mark.parametrize("arguments", [{}, {"query": ""}])
+def test_required_string_validation_is_preserved(arguments):
+    schema = schema_dict_to_model(
+        {
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        }
+    )
+    with pytest.raises(ValidationError):
+        schema(**arguments)


### PR DESCRIPTION
The MCP tool loader raises `KeyError: 'type'` when a server describes an argument with `anyOf` instead of a top-level `type`. This prevents Parallel Search MCP tools from loading. Use the converter's existing `Any` fallback for these schemas while keeping its required-field and primitive validation.

Adds a Chinese developer-guide example using the existing `MultiServerMCPClient` with a pinned `mcp-remote` stdio bridge. Developers can discover `web_search` and `web_fetch` and call web search without a Parallel account or API key. The guide explains the connection lifetime, agent activation, rate limits, and data sent to Parallel. Existing defaults and connections are unchanged. The example targets the Python client interface; it does not describe the WebUI form.

There’s a useful reason to make Parallel easy to try here. The existing search choices are [Bing, DuckDuckGo, Metaphor, and Searx](https://github.com/chatchat-space/Langchain-Chatchat/blob/49165d6af4438aa7e8a1f71ce276db55f4405151/libs/chatchat-server/chatchat/server/agent/tools_factory/search_internet.py#L90-L95). Metaphor [became Exa](https://exa.ai/blog/announcing-exa), and Exa is the only one of those providers on [Artificial Analysis’s Search API leaderboard](https://artificialanalysis.ai/agents/search-api).

In AA’s August 31 results, Parallel advanced scores **76.5% on BrowseComp**, compared with Exa fast at **60.5%**, instant at **65.0%**, and auto at **73.5%**. That’s a **16 percentage point gap** against Exa fast on hard-to-find facts. Parallel advanced also leads all three Exa modes on DeepSearchQA F1: **80.6**, versus Exa auto at **77.8**, fast at **75.7**, and instant at **73.0**. That makes it worth trying for research questions. These are [API benchmark results](https://artificialanalysis.ai/methodology/search-api), not measurements of this free MCP connection or the repo’s older Metaphor adapter.

Search is opt-in here: [DuckDuckGo is the configured backend, with search disabled in the settings](https://github.com/chatchat-space/Langchain-Chatchat/blob/49165d6af4438aa7e8a1f71ce276db55f4405151/libs/chatchat-server/chatchat/settings.py#L489-L491), and [chat only includes explicitly selected tools](https://github.com/chatchat-space/Langchain-Chatchat/blob/49165d6af4438aa7e8a1f71ce276db55f4405151/libs/chatchat-server/chatchat/server/chat/chat.py#L168-L170). This adds a choice without changing that behavior.

Validation:
- Four focused schema tests pass. Two fail with `KeyError` against the original converter, and existing required-string checks pass on both versions.
- Ran the exact documented connection through the repository's MCP client and LangChain tool invocation with Python 3.11, MCP 1.4.1, LangChain Core 0.1.53, and Pydantic 2.11.1. Anonymous discovery returned both tools and the search returned nonempty results with source URLs and excerpts.
- The new test file passes Ruff lint and formatting. The changed converter has the same eight pre-existing lint diagnostics as the base. `git diff --check` passes.

These were focused checks using prebuilt dependencies and isolated imports of the actual MCP modules. No repository build, full application/UI run, LLM execution, or full test suite was run.

I work at Parallel, which operates this service.
